### PR TITLE
--no-nom: fix help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ options:
   -j MAX_JOBS, --max-jobs MAX_JOBS
                         Maximum number of build jobs to run in parallel (0 for unlimited)
   --option name value   Nix option to set
-  --no-nom              Use nix-output-monitor to print build output (default: false)
+  --no-nom              Don't use nix-output-monitor to print build output (default: false)
   --systems SYSTEMS     Comma-separated list of systems to build for (default: current system)
   --retries RETRIES     Number of times to retry failed builds
   --remote REMOTE       Remote machine to build on

--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -143,7 +143,7 @@ async def parse_args(args: list[str]) -> Options:
     )
     parser.add_argument(
         "--no-nom",
-        help="Use nix-output-monitor to print build output (default: false)",
+        help="Don't use nix-output-monitor to print build output (default: false)",
         action="store_true",
         default=None,
     )


### PR DESCRIPTION
Setting this argument *disables* nom usage.