### PR TITLE
Only skip if actually in upstream cache

### DIFF
--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -761,8 +761,10 @@ async def run_evaluation(
         )
         if error:
             continue
-        is_cached = job.get("isCached", False)
-        if is_cached:
+        # Skip remotely cached jobs, but still consider
+        # them for pushing if they are cached locally
+        cache_status = job.get("cacheStatus", "notBuilt")
+        if cache_status == "cached":
             continue
         system = job.get("system")
         if system and system not in opts.systems:


### PR DESCRIPTION
If a derivation is already present in the local Nix store (i.e. if building the same thing with a persisted Nix store on a remote worker) `nix-eval-jobs` will return `{ "isCached": true, "cacheStatus": "local" }`. If the derivation is not present locally but _is_ present in a remote cache, `nix-eval-jobs` will return `{ "isCached": true, "cacheStatus": "cached" }

By changing the behavior of `--skip-cached` to skip all derivations where `cacheStatus == "cached"` we get the added benefit that any previously built derivation already in the store is still eligible for being pushed up to a Cachix or Attic caches when requested (for example, this can be useful if the same, persistent remote builder is used during development and in CI and still ensuring the CI runs will push things to the cache)