### PR TITLE
Flush stdout after printing a progress message

### DIFF
--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -805,6 +805,7 @@ async def run_builds(
                 return 0
             job = next_job
             print(f"  building {job.attr}")
+            sys.stdout.flush()
             if job.drv_path in drv_paths:
                 continue
             drv_paths.add(job.drv_path)


### PR DESCRIPTION
Without this, messages "building XYZ" can appear at the end of the CI log, after all error messages (if there are any). For example, when building three packages pkg1, pkg2 and pkg3, and pkg3 fails with an error message, the output can look like this:

    error: something failed in pkg3
    building pkg1
    building pkg2
    building pkg3

This can be quite confusing, because it appears that the error message from pkg3 was printed before the build has actually started. The reason for incorrect message ordering is that stdout (used for "building XYZ" messages) is fully buffered if not connected to a terminal. Error messages from child processes do not go through the same buffer and can therefore appear earlier, if the child flushes its buffer or writes to stderr, which is line-buffered.