### PR TITLE
fix: replace pkgs.hostPlatform with pkgs.stdenv.hostPlatform

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
             packages.nix-fast-build = pkgs.callPackage ./default.nix {
               # we don't want to compile ghc otherwise
               nix-output-monitor =
-                if lib.elem pkgs.hostPlatform.system officialPlatforms then pkgs.nix-output-monitor else null;
+                if lib.elem pkgs.stdenv.hostPlatform.system officialPlatforms then pkgs.nix-output-monitor else null;
             };
             legacyPackages = {
               hello-broken = pkgs.hello.overrideAttrs (_old: {

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -9,7 +9,7 @@
         # Used to find the project root
         projectRootFile = ".git/config";
 
-        flakeCheck = pkgs.hostPlatform.system != "riscv64-linux";
+        flakeCheck = pkgs.stdenv.hostPlatform.system != "riscv64-linux";
 
         programs.deno.enable = pkgs.lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.deno;
         programs.mypy.enable = true;


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/4e7c982139775f67f33e73c9c2fe60d082d36125/pkgs/top-level/aliases.nix#L694

```
evaluation warning: 'hostPlatform' has been renamed to/replaced by 'stdenv.hostPlatform'
error: attempt to call something which is not a function but a string: "system"
at «github:Mic92/nix-fast-build/41d0b008bb6fb8583ab3e0ce84941f4b0f13b787?narHash=sha256-rNvRHfYD5A7cRGYTxDQyNKUsrJQLBkv9mPREccZ/BNs%3D»/flake.nix:35:29:
    34|               nix-output-monitor =
    35|                 if lib.elem pkgs.hostPlatform.system officialPlatforms then pkgs.nix-output-monitor else null;
      |                             ^
    36|             };
```
