### PR TITLE
pyproject.toml: Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nix-fast-build"
 description = "Evaluate and build in parallel"
 version = "1.3.0"
 authors = [{ name = "Jörg Thalheim", email = "joerg@thalheim.io" }]
-license = { text = "MIT" }
+license = "MIT"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",


### PR DESCRIPTION
Other license specification formats are deprecated and going away in 2026-02.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

```
nix-fast-build> /nix/store/5f3q6rfkg20v4rpwp19nin1c2dkxm8dy-python3.11-setuptools-80.9.0/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
nix-fast-build> !!
nix-fast-build>         ********************************************************************************
nix-fast-build>         Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
nix-fast-build>         By 2026-Feb-18, you need to update your project and remove deprecated calls
nix-fast-build>         or your builds will no longer be supported.
nix-fast-build>         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
nix-fast-build>         ********************************************************************************
nix-fast-build> !!
```