### PR TITLE
workflows: add one-time export of radicle secrets

### DIFF
--- a/.github/workflows/export-radicle-secrets.yaml
+++ b/.github/workflows/export-radicle-secrets.yaml
@@ -1,0 +1,52 @@
+name: Export Radicle Secrets
+on:
+  workflow_dispatch:
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    environment: radicle
+    steps:
+      - name: Install age
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y age
+
+      - name: Export and encrypt secrets
+        env:
+          RADICLE_IDENTITY_ALIAS: ${{ secrets.RADICLE_IDENTITY_ALIAS }}
+          RADICLE_IDENTITY_PASSPHRASE: ${{ secrets.RADICLE_IDENTITY_PASSPHRASE }}
+          RADICLE_IDENTITY_PRIVATE_KEY: ${{ secrets.RADICLE_IDENTITY_PRIVATE_KEY }}
+          RADICLE_IDENTITY_PUBLIC_KEY: ${{ secrets.RADICLE_IDENTITY_PUBLIC_KEY }}
+          RADICLE_PROJECT_NAME: ${{ secrets.RADICLE_PROJECT_NAME }}
+          RADICLE_REPOSITORY_ID: ${{ secrets.RADICLE_REPOSITORY_ID }}
+          AGE_RECIPIENT: age1nnm255ah9wa4gpsaq0v023a75lnmlcxszt9lc6az3mtwzxgrucfq45rp7h
+        run: |
+          # Create JSON with all secrets
+          cat > /tmp/secrets.json << EOF
+          {
+            "alias": "$RADICLE_IDENTITY_ALIAS",
+            "passphrase_b64": "$RADICLE_IDENTITY_PASSPHRASE",
+            "private_key_b64": "$RADICLE_IDENTITY_PRIVATE_KEY",
+            "public_key_b64": "$RADICLE_IDENTITY_PUBLIC_KEY",
+            "project_name": "$RADICLE_PROJECT_NAME",
+            "rid": "$RADICLE_REPOSITORY_ID",
+            "github_repo": "${{ github.repository }}"
+          }
+          EOF
+
+          # Encrypt with age
+          age -r "$AGE_RECIPIENT" -a /tmp/secrets.json > /tmp/secrets.json.age
+
+          echo "=== Encrypted secrets (copy this) ==="
+          cat /tmp/secrets.json.age
+          echo "=== End of encrypted secrets ==="
+
+          # Clean up
+          rm -f /tmp/secrets.json
+
+      - name: Upload encrypted secrets
+        uses: actions/upload-artifact@v4
+        with:
+          name: radicle-secrets-encrypted
+          path: /tmp/secrets.json.age
+          retention-days: 1


### PR DESCRIPTION
Export existing radicle credentials from GitHub secrets encrypted with age for import into rbw.