### PR TITLE
Guard against empty `outputs`

### DIFF
--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -845,7 +845,7 @@ class Build:
         return await proc.wait()
 
     async def upload(self, exit_stack: AsyncExitStack, opts: Options) -> int:
-        if not opts.copy_to:
+        if not opts.copy_to or not self.outputs:
             return 0
         cmd = opts.nix_command(
             [
@@ -866,7 +866,7 @@ class Build:
     async def upload_cachix(
         self, cachix_socket_path: Path | None, opts: Options
     ) -> int:
-        if cachix_socket_path is None:
+        if cachix_socket_path is None or not self.outputs:
             return 0
         cmd = maybe_remote(
             [
@@ -903,7 +903,7 @@ class Build:
         return await proc.wait()
 
     async def download(self, exit_stack: AsyncExitStack, opts: Options) -> int:
-        if not opts.remote_url or not opts.download:
+        if not opts.remote_url or not opts.download or not self.outputs:
             return 0
         cmd = opts.nix_command(
             [


### PR DESCRIPTION
My second commit (https://github.com/Mic92/nix-fast-build/commit/6a4a79ce087c21deb0547fefaa58f5eca100ec34) in https://github.com/Mic92/nix-fast-build/pull/301 seems to be trimmed (https://github.com/Mic92/nix-fast-build/pull/301/commits/59c18732f79a07a9dab90cafbd69a68cdbd065f8) to exclude these changes, but I am not sure if that was on purpose.

Without the guard against empty `outputs` on `cachix_socket_path` line, I get
```
You need to specify store paths either as stdin or as a command argumentINFO:nix_fast_build:builds: 0
  building x86_64-linux.pre-commit
ERROR:nix_fast_build:CACHIX: 1 successes, 1 failures
ERROR:nix_fast_build:Failed attributes: .#checks.x86_64-linux.trufflehog
[2026-03-19 19:48:36][Info] Shutting down daemon...
```
when `--cachix-cache <cache>` is used with impure derivations.

I didn't tested the other two code paths personally using `nix-fast-build` but something like `nix copy --log-format raw --to "file:///tmp/cache?compression=none"` without any installables seem to default to the current flake (as opposed to no-op), which makes me believe the guard is required there too.