### PR TITLE
fix: remove all 7-bit and CSI ansi codes

### DIFF
--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -1313,7 +1313,19 @@ def strip_ansi(raw: str) -> str:
     Removes ANSI escape sequences as defined by ECMA-048 in
     https://www.ecma-international.org/wp-content/uploads/ECMA-48_5th_edition_june_1991.pdf
     """
-    return re.compile(r"\x1B\[\d+(;\d+){0,2}m").sub("", raw)
+    return re.compile(
+        r"""
+    \x1B  # ESC
+    (?:   # 7-bit C1 Fe (except CSI)
+        [@-Z\\-_]
+    |     # or [ for CSI, followed by a control sequence
+        \[
+        [0-?]*  # Parameter bytes
+        [ -/]*  # Intermediate bytes
+        [@-~]   # Final byte
+    )""",
+        re.VERBOSE,
+    ).sub("", raw)
 
 
 def get_ci_summary_file() -> Path | None:


### PR DESCRIPTION
The previous implementation for stripping ANSI did not catch all ANSI codes, leading to some making it through to the GitHub logs. This implementation is directly pulled from the following stack overflow post: https://stackoverflow.com/a/14693789. It should catch all currently used (UTF-8 incompatible) ANSI codes as defined in the ECMA 48 standard.
