### PR TITLE
create-release: push release branch by explicit refspec

### DIFF
--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -49,9 +49,9 @@ sed -i -e "s!^version = \".*\"\$!version = \"${version}\"!" pyproject.toml
 git add pyproject.toml default.nix
 nix flake check -vL
 git branch -D "release-${version}" || true
-git checkout -b "release-${version}"
+git checkout --no-track -b "release-${version}"
 git commit -m "bump version ${version}"
-git push origin "release-${version}"
+git push origin "HEAD:refs/heads/release-${version}"
 pr_url=$(gh pr create \
   --base main \
   --head "release-${version}" \


### PR DESCRIPTION
With push.default=upstream and branch.autoSetupMerge=always the
release branch tracks main, so 'git push origin release-X' resolved
to refs/heads/main and was rejected by branch protection. Create the
branch with --no-track and push HEAD to an explicit refspec so the
script works regardless of the user's git config.
