### PR TITLE
cli: add --select to filter/transform the evaluation root

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ $ nix run github:Mic92/nix-fast-build -- --flake github:NixOS/nixpkgs#legacyPack
 `nix-fast-build` does not iterate over different attributes; the full path must
 be explicitly stated.
 
+## Excluding or filtering attributes
+
+Use `--select` to pass a Nix function to `nix-eval-jobs` that transforms the
+evaluation root before traversal. The function receives the attribute selected
+by `--flake` (or `-A` in `--file` mode), so you can drop expensive jobs or pick
+a subset without changing your flake:
+
+```console
+$ nix-fast-build --flake .#checks.x86_64-linux \
+    --select 'checks: builtins.removeAttrs checks ["slow-integration-test"]'
+```
+
 ## Only evaluate the current system
 
 By default nix-fast-build will evaluate all systems in `.#checks`, you can limit
@@ -268,12 +280,15 @@ nix-shell -p python3Packages.junit2html --run 'junit2html result.xml result.html
 ## Reference
 
 ```console
-usage: nix-fast-build [-h] [-f FLAKE | --file [EXPR]] [-A ATTR]
-                      [--arg name value] [--argstr name value] [-I INCLUDE]
-                      [--impure] [--pure] [-j MAX_JOBS] [--option name value]
-                      [--remote-ssh-option name value]
+usage: nix-fast-build [-h] [--nix NIX] [--nix-eval-jobs NIX_EVAL_JOBS]
+                      [--nix-build NIX_BUILD] [-f FLAKE | --file [FILE]]
+                      [-A ATTR] [--arg name value] [--argstr name value]
+                      [-I INCLUDE] [--impure] [--pure] [-j MAX_JOBS]
+                      [--option name value] [--remote-ssh-option name value]
                       [--cachix-cache CACHIX_CACHE]
                       [--attic-cache ATTIC_CACHE]
+                      [--attic-ignore-upstream-cache-filter]
+                      [--attic-push-build-closure]
                       [--niks3-server NIKS3_SERVER] [--no-nom]
                       [--systems SYSTEMS] [--retries RETRIES] [--no-link]
                       [--out-link OUT_LINK] [--remote REMOTE]
@@ -284,11 +299,20 @@ usage: nix-fast-build [-h] [-f FLAKE | --file [EXPR]] [-A ATTR]
                       [--result-file RESULT_FILE]
                       [--result-format {json,junit}]
                       [--override-input input_path flake_url]
+                      [--select NIX_FUNCTION]
 
 options:
   -h, --help            show this help message and exit
+  --nix NIX             Path to the nix binary (default: $NIX_FAST_BUILD_NIX
+                        or 'nix')
+  --nix-eval-jobs NIX_EVAL_JOBS
+                        Path to the nix-eval-jobs binary (default:
+                        $NIX_FAST_BUILD_EVAL_JOBS or 'nix-eval-jobs')
+  --nix-build NIX_BUILD
+                        Path to the nix-build binary (default:
+                        $NIX_FAST_BUILD_NIX_BUILD or 'nix-build')
   -f, --flake FLAKE     Flake url to evaluate/build (default: .#checks)
-  --file [EXPR]         Nix expression file to evaluate (default:
+  --file [FILE]         Nix expression file to evaluate (default:
                         default.nix). Mutually exclusive with --flake.
   -A, --attr ATTR       Attribute path to evaluate in non-flake mode (like
                         nix-build -A)
@@ -311,6 +335,15 @@ options:
                         Cachix cache to upload to
   --attic-cache ATTIC_CACHE
                         Attic cache to upload to
+  --attic-ignore-upstream-cache-filter
+                        Pass --ignore-upstream-cache-filter to attic push,
+                        uploading all paths even if attic thinks they exist in
+                        an upstream cache (default: false)
+  --attic-push-build-closure
+                        Also push the build-time closure to attic, not just
+                        the runtime closure. Useful for caching intermediate
+                        build products in ephemeral CI environments (default:
+                        false)
   --niks3-server NIKS3_SERVER
                         Niks3 server URL to upload to (auth from
                         ~/.config/niks3/auth-token or NIKS3_AUTH_TOKEN_FILE)
@@ -345,4 +378,11 @@ options:
   --override-input input_path flake_url
                         Override a specific flake input (e.g.
                         `dwarffs/nixpkgs`).
+  --select NIX_FUNCTION
+                        Nix function applied to the evaluation root to filter
+                        or transform the set of attributes to build (passed
+                        through to nix-eval-jobs --select). The function
+                        receives the attribute selected by --flake/-A.
+                        Example: 'checks: builtins.removeAttrs checks ["slow-
+                        test"]'
 ```

--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -96,6 +96,7 @@ class Options:
     result_format: ResultFormat = ResultFormat.JSON
     result_file: Path | None = None
     override_inputs: list[list[str]] = field(default_factory=list)
+    select_expr: str | None = None
 
     cachix_cache: str | None = None
 
@@ -401,6 +402,18 @@ async def parse_args(args: list[str]) -> Options:
         metavar=("input_path", "flake_url"),
         help="Override a specific flake input (e.g. `dwarffs/nixpkgs`).",
     )
+    parser.add_argument(
+        "--select",
+        metavar="NIX_FUNCTION",
+        default=None,
+        help=(
+            "Nix function applied to the evaluation root to filter or "
+            "transform the set of attributes to build (passed through to "
+            "nix-eval-jobs --select). The function receives the attribute "
+            "selected by --flake/-A. "
+            "Example: 'checks: builtins.removeAttrs checks [\"slow-test\"]'"
+        ),
+    )
 
     a = parser.parse_args(args)
 
@@ -525,6 +538,7 @@ async def parse_args(args: list[str]) -> Options:
         result_format=ResultFormat[a.result_format.upper()],
         result_file=a.result_file,
         override_inputs=a.override_input,
+        select_expr=a.select,
     )
 
 
@@ -690,6 +704,8 @@ async def nix_eval_jobs(tmp_dir: Path, opts: Options) -> AsyncIterator[Process]:
                 f"{opts.flake_url}#{opts.flake_fragment}",
             ]
         )
+        if opts.select_expr is not None:
+            args.extend(["--select", opts.select_expr])
         if opts.override_inputs:
             for override in opts.override_inputs:
                 args.append("--override-input")
@@ -698,10 +714,16 @@ async def nix_eval_jobs(tmp_dir: Path, opts: Options) -> AsyncIterator[Process]:
     else:
         # Non-flake mode: pass expression file as positional arg
         args.extend(opts.expr_args)
-        if opts.expr_attr:
-            # Use --select to navigate to the desired attribute path,
-            # similar to nix-build -A but using nix-eval-jobs' native API
+        # nix-eval-jobs only accepts a single --select, so compose -A
+        # navigation with any user-supplied select function.
+        if opts.expr_attr and opts.select_expr is not None:
+            args.extend(
+                ["--select", f"root: ({opts.select_expr}) (root.{opts.expr_attr})"]
+            )
+        elif opts.expr_attr:
             args.extend(["--select", f"root: root.{opts.expr_attr}"])
+        elif opts.select_expr is not None:
+            args.extend(["--select", opts.select_expr])
         args.append(opts.expr_file)
     if opts.skip_cached:
         args.append("--check-cache-status")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,40 @@ def test_eval_error() -> None:
     assert rc == 1
 
 
+def test_select_flake() -> None:
+    """--select can filter out failing attributes so the build succeeds."""
+    rc = cli(
+        [
+            "--option",
+            "builders",
+            "",
+            "--flake",
+            ".#legacyPackages",
+            "--select",
+            # legacyPackages.<system> only contains intentionally broken
+            # packages; filtering them all out must yield a successful run.
+            "systems: builtins.mapAttrs (_: _: { }) systems",
+        ]
+    )
+    assert rc == 0
+
+
+def test_select_expr() -> None:
+    """--select is forwarded to nix-eval-jobs in non-flake mode."""
+    rc = cli(
+        [
+            "--file",
+            str(FIXTURES / "simple.nix"),
+            "--select",
+            "root: { inherit (root) hello; }",
+            "--option",
+            "builders",
+            "",
+        ]
+    )
+    assert rc == 0
+
+
 def test_expr_build() -> None:
     """Non-flake mode: evaluate and build a simple Nix expression."""
     rc = cli(


### PR DESCRIPTION
Exposes `nix-eval-jobs --select` so users can exclude or transform attributes without editing their flake.

```console
$ nix-fast-build --flake .#checks.x86_64-linux \
    --select 'checks: builtins.removeAttrs checks ["slow-integration-test"]'
```

- Works in both `--flake` and `--file` mode (composed with `-A` since nix-eval-jobs takes a single `--select`).
- Tests added.
- README Reference section regenerated from `--help`.

Closes #287