### PR TITLE
cli: add --store to build against a remote store

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,34 @@ Replace `youruser@yoursshhostname` with your SSH login credentials for the
 target machine. Please note that as of now, you must be recognized as a trusted
 user on the remote endpoint to access this feature.
 
+## Building against a remote store
+
+`--store` dispatches builds to a Nix store URL — like `nix build --store` —
+while still evaluating locally:
+
+```
+nix run github:Mic92/nix-fast-build -- --store ssh-ng://youruser@yoursshhostname
+```
+
+This is a thinner mechanism than `--remote`: it uses the Nix store protocol
+instead of running the whole pipeline over SSH shell exec. Pick whichever
+matches your setup:
+
+| Flag       | Mechanism                                       | Eval    | Outputs                | Uploads (`--copy-to`, cachix, attic, niks3) |
+| ---------- | ----------------------------------------------- | ------- | ---------------------- | ------------------------------------------- |
+| `--remote` | SSH in, run `nix-eval-jobs` + `nix build` there | On host | Copied back by default | Supported                                   |
+| `--store`  | `nix build --store <url>`                       | Local   | Stay in the store      | Not supported                               |
+
+`--store` is well suited to CI gates ("does this build?") where outputs do not
+need to come back. It implies `--no-link`, since result symlinks would point at
+paths that don't exist locally. It is mutually exclusive with `--remote`,
+`--copy-to`, `--cachix-cache`, `--attic-cache`, `--niks3-server`, and
+`--out-link`.
+
+`--skip-cached` checks the local store and configured substituters; it cannot
+see the contents of a remote `--store`. Derivations whose outputs already exist
+on the remote but nowhere locally will be re-queued, then no-op on the server.
+
 ## CI-Friendly Output
 
 By default, `Nix-output-monitor` (abbreviated as `nom`) updates its output every

--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -78,6 +78,7 @@ class Options:
     expr_args: list[str] = field(default_factory=list)
     impure: bool = False
     options: list[str] = field(default_factory=list)
+    store: str | None = None
     remote: str | None = None
     remote_ssh_options: list[str] = field(default_factory=list)
     always_upload_source: bool = False
@@ -116,6 +117,19 @@ class Options:
         if self.remote is None:
             return None
         return f"ssh://{self.remote}"
+
+    @property
+    def store_args(self) -> list[str]:
+        """Args to append to nix commands that operate on the build store.
+
+        --eval-store auto is mandatory: without it, ``nix build --store X
+        <local-drv>^*`` follows ``eval-store=auto``'s "default to --store"
+        behaviour, fails to find the locally-evaluated .drv on the remote
+        store, and re-evaluates from scratch there.
+        """
+        if self.store is None:
+            return []
+        return ["--eval-store", "auto", "--store", self.store]
 
     @property
     def display_name(self) -> str:
@@ -343,6 +357,15 @@ async def parse_args(args: list[str]) -> Options:
         default="result",
     )
     parser.add_argument(
+        "--store",
+        type=str,
+        help=(
+            "Nix store to build against (e.g. ssh-ng://my-remote). Evaluation "
+            "always happens locally; only builds are dispatched to the given "
+            "store. Build outputs stay in that store. Implies --no-link."
+        ),
+    )
+    parser.add_argument(
         "--remote",
         type=str,
         help="Remote machine to build on",
@@ -427,6 +450,47 @@ async def parse_args(args: list[str]) -> Options:
 
     # Determine evaluation mode
     eval_mode = EvalMode.EXPR if a.file is not None else EvalMode.FLAKE
+
+    # Validate: --store conflicts. Outputs built with --store stay in the
+    # remote store, so anything that reads outputs from the local store (or
+    # depends on a particular store URL) cannot work alongside it.
+    if a.store:
+        if a.remote:
+            parser.error(
+                "--store and --remote are mutually exclusive: "
+                "--remote runs the whole pipeline over SSH, "
+                "--store dispatches builds via a Nix store URL"
+            )
+        if a.copy_to:
+            parser.error(
+                "--copy-to reads outputs from the local store; "
+                "outputs built with --store stay in the remote store"
+            )
+        if a.cachix_cache:
+            parser.error(
+                "--cachix-cache reads outputs from the local store; "
+                "outputs built with --store stay in the remote store"
+            )
+        if a.attic_cache:
+            parser.error(
+                "--attic-cache reads outputs from the local store; "
+                "outputs built with --store stay in the remote store"
+            )
+        if a.niks3_server:
+            parser.error(
+                "--niks3-server reads outputs from the local store; "
+                "outputs built with --store stay in the remote store"
+            )
+        if a.out_link != "result":
+            parser.error(
+                "--out-link is not supported with --store: "
+                "outputs stay in the remote store, the symlink would dangle"
+            )
+        if any(name in ("store", "eval-store") for name, _ in a.option):
+            parser.error(
+                "--option store/eval-store conflicts with --store; "
+                "use --store to set the build store"
+            )
 
     # Validate: --remote is not supported in non-flake mode
     if eval_mode == EvalMode.EXPR and a.remote:
@@ -541,7 +605,10 @@ async def parse_args(args: list[str]) -> Options:
         attic_ignore_upstream_cache_filter=a.attic_ignore_upstream_cache_filter,
         attic_push_build_closure=a.attic_push_build_closure,
         niks3_server=a.niks3_server,
-        no_link=a.no_link,
+        store=a.store,
+        # Outputs land in the build store, not locally — a result symlink
+        # would dangle. See "Out-link" validation above.
+        no_link=a.no_link or bool(a.store),
         out_link=a.out_link,
         result_format=ResultFormat[a.result_format.upper()],
         result_file=a.result_file,
@@ -863,7 +930,11 @@ class Build:
 
     async def get_build_log(self, opts: Options) -> str:
         """Get build log using nix log command."""
-        cmd = maybe_remote(opts.nix_command(["log", self.drv_path]), opts)
+        # Logs live in the build store. With --store, that's not the local
+        # store, so nix log must be pointed at the same store nix build used.
+        cmd = maybe_remote(
+            opts.nix_command(["log", self.drv_path, *opts.store_args]), opts
+        )
         logger.debug("run %s", shlex.join(cmd))
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -1060,7 +1131,7 @@ async def nix_build(
     nom_pipe: IO[bytes] | None = None,
 ) -> AsyncIterator[Process]:
     args = opts.nix_command(
-        ["build", f"{installable}^*", "--keep-going", *opts.options]
+        ["build", f"{installable}^*", "--keep-going", *opts.options, *opts.store_args]
     )
     if nom_pipe is not None:
         args += ["--log-format", "internal-json", "-v"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from nix_fast_build import async_main
+from nix_fast_build import Build, Options, async_main, parse_args
 
 from .sshd import Sshd
 
@@ -197,6 +197,150 @@ def test_remote(sshd: Sshd) -> None:
             "--remote-ssh-option",
             "UserKnownHostsFile",
             "/dev/null",
+        ]
+    )
+    assert rc == 0
+
+
+def test_store_args_property() -> None:
+    """store_args must always pin --eval-store auto so nix build finds the
+    locally-evaluated .drv instead of re-evaluating against the remote store."""
+    opts = Options(store="ssh-ng://example.org")
+    assert opts.store_args == [
+        "--eval-store",
+        "auto",
+        "--store",
+        "ssh-ng://example.org",
+    ]
+
+
+def test_store_args_property_none() -> None:
+    """No store flag set means no extra args."""
+    opts = Options(store=None)
+    assert opts.store_args == []
+
+
+def test_store_implies_no_link() -> None:
+    """--store implies --no-link: outputs land in the remote store, so a
+    local out-link symlink would dangle."""
+    opts = asyncio.run(parse_args(["--store", "ssh-ng://example.org"]))
+    assert opts.store == "ssh-ng://example.org"
+    assert opts.no_link is True
+
+
+def test_store_remote_rejected() -> None:
+    """--store and --remote are different remote-build mechanisms."""
+    with pytest.raises(SystemExit) as e:
+        cli(["--store", "ssh-ng://x", "--remote", "y"])
+    assert e.value.code == 2
+
+
+def test_store_copy_to_rejected() -> None:
+    """nix copy reads from the local store; --store outputs aren't there."""
+    with pytest.raises(SystemExit) as e:
+        cli(["--store", "ssh-ng://x", "--copy-to", "file:///tmp/cache"])
+    assert e.value.code == 2
+
+
+def test_store_cachix_rejected() -> None:
+    """cachix reads from the local store; --store outputs aren't there."""
+    with pytest.raises(SystemExit) as e:
+        cli(["--store", "ssh-ng://x", "--cachix-cache", "mycache"])
+    assert e.value.code == 2
+
+
+def test_store_attic_rejected() -> None:
+    """attic reads from the local store; --store outputs aren't there."""
+    with pytest.raises(SystemExit) as e:
+        cli(["--store", "ssh-ng://x", "--attic-cache", "mycache"])
+    assert e.value.code == 2
+
+
+def test_store_niks3_rejected() -> None:
+    """niks3 reads from the local store; --store outputs aren't there."""
+    with pytest.raises(SystemExit) as e:
+        cli(["--store", "ssh-ng://x", "--niks3-server", "https://x"])
+    assert e.value.code == 2
+
+
+def test_store_out_link_rejected() -> None:
+    """A result symlink would dangle: outputs live in the remote store."""
+    with pytest.raises(SystemExit) as e:
+        cli(["--store", "ssh-ng://x", "--out-link", "build-result"])
+    assert e.value.code == 2
+
+
+def test_store_option_store_rejected() -> None:
+    """--option store and --store are ambiguous about which value wins."""
+    with pytest.raises(SystemExit) as e:
+        cli(["--store", "ssh-ng://x", "--option", "store", "ssh-ng://y"])
+    assert e.value.code == 2
+
+
+def test_store_option_eval_store_rejected() -> None:
+    """--option eval-store conflicts with the auto eval-store --store implies."""
+    with pytest.raises(SystemExit) as e:
+        cli(["--store", "ssh-ng://x", "--option", "eval-store", "local"])
+    assert e.value.code == 2
+
+
+def test_store_unusable_fails_build() -> None:
+    """An unusable --store must cause builds to fail.
+
+    Proves --store actually reaches nix build, not just argparse: nix
+    rejects an unknown store scheme synchronously when opening the store,
+    so this fails fast and without a real remote.
+    """
+    rc = cli(
+        [
+            "--option",
+            "builders",
+            "",
+            "--store",
+            "totally-bogus-scheme://x",
+        ]
+    )
+    assert rc != 0
+
+
+def test_store_args_reach_get_build_log() -> None:
+    """The build log lives in the build store; nix log must be pointed there.
+
+    nix log against an unknown store scheme errors with a message naming the
+    scheme, while nix log against the local store for a missing path errors
+    with "build log ... is not available". The scheme name in the returned
+    log proves nix log was invoked with --store.
+    """
+    opts = Options(store="totally-bogus-scheme://x")
+    b = Build(
+        attr="x",
+        drv_path="/nix/store/" + "a" * 32 + "-fake.drv",
+        outputs={},
+    )
+    log = asyncio.run(b.get_build_log(opts))
+    assert "totally-bogus-scheme" in log
+
+
+def test_store_ssh_ng(sshd: Sshd, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end build against an ssh-ng:// store.
+
+    Unlike --remote (ssh shell exec), --store ssh-ng:// streams the daemon
+    protocol over an SSH channel. ssh-ng:// has no per-store SSH option
+    flags, so port/key go through NIX_SSHOPTS like nix itself documents.
+    """
+    login = pwd.getpwuid(os.getuid()).pw_name
+    monkeypatch.setenv(
+        "NIX_SSHOPTS",
+        f"-p {sshd.port} -i {sshd.key} "
+        f"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+    )
+    rc = cli(
+        [
+            "--option",
+            "builders",
+            "",
+            "--store",
+            f"ssh-ng://{login}@127.0.0.1",
         ]
     )
     assert rc == 0


### PR DESCRIPTION
## Summary

Adds `--store <STORE_URL>` to dispatch builds to a Nix store URL (`ssh-ng://`, `unix://`, etc.) the way `nix build --store` does, while still evaluating locally. This is a thinner mechanism than `--remote`: it speaks the Nix store protocol only and never needs `nix-eval-jobs` or shell exec on the remote side, which makes it well suited to CI gates ("does this build?") where outputs do not need to come back to the local machine.

| Flag       | Mechanism                                       | Eval    | Outputs                | Uploads (`--copy-to`, cachix, attic, niks3) |
| ---------- | ----------------------------------------------- | ------- | ---------------------- | ------------------------------------------- |
| `--remote` | SSH in, run `nix-eval-jobs` + `nix build` there | On host | Copied back by default | Supported                                   |
| `--store`  | `nix build --store <url>`                       | Local   | Stay in the store      | Not supported                               |

### Design notes

- `--eval-store auto` is always passed alongside `--store` on `nix build` and `nix log`. Without it, `eval-store` defaults to following `--store`, so `nix build` would fail to find the locally-evaluated `.drv` and re-evaluate from scratch against the remote store.
- `--store` implies `--no-link`: result symlinks would dangle since outputs land in the build store.
- Mutually exclusive (hard error) with `--remote`, `--copy-to`, `--cachix-cache`, `--attic-cache`, `--niks3-server`, `--out-link`, and `--option store`/`--option eval-store`. The upload destinations all read from the local store, which doesn't have the outputs.
- `--skip-cached` is a documented limitation: `nix-eval-jobs --check-cache-status` cannot see the contents of the remote build store, so derivations whose outputs already exist there but nowhere locally will be re-queued (and then no-op on the server side).

## Test plan

- [x] `Options.store_args` always pins `--eval-store auto` (`test_store_args_property`, `test_store_args_property_none`)
- [x] `--store` implies `--no-link` (`test_store_implies_no_link`)
- [x] Hard errors for conflicting flags: `--remote`, `--copy-to`, `--cachix-cache`, `--attic-cache`, `--niks3-server`, `--out-link`, `--option store`, `--option eval-store` (8 `test_store_*_rejected` tests)
- [x] `--store` actually reaches `nix build`: an unknown store scheme makes builds fail (`test_store_unusable_fails_build`)
- [x] `--store` actually reaches `nix log`: the returned log names the store scheme (`test_store_args_reach_get_build_log`)
- [x] End-to-end build against `ssh-ng://127.0.0.1` using the test sshd fixture (`test_store_ssh_ng`)
- [x] `treefmt` check passes (ruff, mypy, deadnix, nixfmt, deno)