### PR TITLE
Pass -L to nix build when nom is disabled

### DIFF
--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -1120,6 +1120,10 @@ async def nix_build(
     )
     if nom_pipe is not None:
         args += ["--log-format", "internal-json", "-v"]
+    else:
+        # Without nom, stream build logs directly to stderr so the user
+        # can see what builders are doing (especially useful in CI).
+        args += ["-L"]
     if opts.no_link:
         args += ["--no-link"]
     else:


### PR DESCRIPTION
Without nom, nix build runs with no log verbosity flags, so build output is silently discarded. This makes CI failures hard to diagnose since users only see "build exited with 1" and must fetch logs separately.

Pass `-L` (`--print-build-logs`) when nom is not in use so build output streams to stderr naturally.

Fixes #337