### PR TITLE
Parse version from pyproject.toml instead of duplicating it

### DIFF
--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -44,9 +44,8 @@ if git tag -l | grep -q "^${version}\$"; then
   echo "Tag ${version} already exists, exiting" >&2
   exit 1
 fi
-sed -i -e "s!version = \".*\";!version = \"${version}\";!" default.nix
 sed -i -e "s!^version = \".*\"\$!version = \"${version}\"!" pyproject.toml
-git add pyproject.toml default.nix
+git add pyproject.toml
 nix flake check -vL
 git branch -D "release-${version}" || true
 git checkout --no-track -b "release-${version}"

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ let
 in
 python3Packages.buildPythonApplication {
   pname = "nix-fast-build";
-  version = "1.6.0";
+  version = (lib.trivial.importTOML ./pyproject.toml).project.version;
   format = "pyproject";
   src = ./.;
   buildInputs = with python3Packages; [


### PR DESCRIPTION
The version was duplicated in both pyproject.toml and default.nix, requiring the release script to update two files. default.nix now reads the version from pyproject.toml via `importTOML`, making pyproject.toml the single source of truth.