### PR TITLE
add support streamed jsonl output

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,22 @@ nix-fast-build --result-format junit --result-file result.xml
 nix-shell -p python3Packages.junit2html --run 'junit2html result.xml result.html'
 ```
 
+### Streaming results as JSON Lines
+
+With `--stream-json-lines`, nix-fast-build prints one JSON object per result
+(evaluation, build, upload, download) to standard output as soon as it is
+available, similar to nix-eval-jobs. All logs and build output go to standard
+error, so stdout contains only JSON Lines. This implies `--no-nom`.
+
+```console
+nix-fast-build --stream-json-lines
+{"type": "EVAL", "attr": "x86_64-linux.package-default", "success": true, "duration": 0.0, "error": null}
+{"type": "BUILD", "attr": "x86_64-linux.package-default", "success": true, "duration": 1.2, "error": null, "outputs": {"out": "/nix/store/..."}}
+```
+
+This is useful for CI integrations that want to react to results as they happen,
+e.g. setting per-attribute commit statuses.
+
 ## Reference
 
 ```console
@@ -309,7 +325,7 @@ usage: nix-fast-build [-h] [--nix NIX] [--nix-eval-jobs NIX_EVAL_JOBS]
                       [--eval-max-memory-size EVAL_MAX_MEMORY_SIZE]
                       [--eval-workers EVAL_WORKERS]
                       [--result-file RESULT_FILE]
-                      [--result-format {json,junit}]
+                      [--result-format {json,junit}] [--stream-json-lines]
                       [--override-input input_path flake_url]
                       [--select NIX_FUNCTION]
                       [--reference-lock-file REFERENCE_LOCK_FILE]
@@ -389,6 +405,7 @@ options:
                         File to write build results to
   --result-format {json,junit}
                         Format of the build result file
+  --stream-json-lines   Stream results to standard output as JSON Lines
   --override-input input_path flake_url
                         Override a specific flake input (e.g.
                         `dwarffs/nixpkgs`).

--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -253,9 +253,9 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
 async def async_main(args: list[str]) -> int:
     opts = await parse_args(args)
     if opts.debug:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 
     stack = AsyncExitStack()
     # using async wait here seems to make the return value skipped in the non-execptional case

--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -1,7 +1,8 @@
 import asyncio
+import json
 import logging
 import sys
-from asyncio import TaskGroup
+from asyncio import Queue, TaskGroup
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
@@ -75,6 +76,7 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
             run_cachix_daemon(stack, tmp_dir, opts.cachix_cache, opts)
         )
     results: list[Result] = []
+    result_queue: Queue[Result | None] = Queue()
     build_queue = JobQueue()
 
     # Build list of optional queues that are actually needed
@@ -91,7 +93,7 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
                 queue,
                 opts.max_jobs,
                 name,
-                lambda: run_queue_worker(queue, results, result_type, name, push),
+                lambda: run_queue_worker(queue, result_queue, result_type, name, push),
             )
         )
         return queue
@@ -120,27 +122,38 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
                 niks3_queue,
                 1,
                 "niks3",
-                lambda: run_niks3_upload(niks3_queue, results, opts),
+                lambda: run_niks3_upload(niks3_queue, result_queue, opts),
             )
         )
 
     if opts.remote_url and opts.download:
         add_queue("download", ResultType.DOWNLOAD, lambda b: b.download(stack, opts))
 
+    async def dequeue_results() -> None:
+        # Stream results as they arrive and collect them for the final
+        # summary and result file. A None sentinel stops the task.
+        while True:
+            result = await result_queue.get()
+            if result is None:
+                return
+            if opts.stream_json_lines:
+                print(json.dumps(result.as_dict()), flush=True)
+            results.append(result)
+
     async with TaskGroup() as tg:
-        tasks = []
-        tasks.append(
-            tg.create_task(
-                run_evaluation(eval_proc, build_queue, upload_queue, results, opts)
-            )
+        tasks: list[asyncio.Task[object]] = []
+        dequeue_task = tg.create_task(dequeue_results(), name="dequeue-results")
+        tasks.append(dequeue_task)
+        evaluation = tg.create_task(
+            run_evaluation(eval_proc, build_queue, upload_queue, result_queue, opts)
         )
-        evaluation = tasks[0]
+        tasks.append(evaluation)
         # When nom is enabled, each nix-build captures its own stderr and
         # forwards complete lines to the shared nom pipe, avoiding
         # interleaved writes from concurrent builds.  build_output is only
         # used as the nix-build stderr fd when nom is *not* active.
         nom_pipe: IO[bytes] | None = pipe.write_file if pipe else None
-        build_output = sys.stdout.buffer
+        build_output = sys.stderr.buffer
         logger.debug("Starting %d build tasks", opts.max_jobs)
         tasks.extend(
             tg.create_task(
@@ -149,7 +162,7 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
                     build_output,
                     build_queue,
                     [oq.queue for oq in optional_queues],
-                    results,
+                    result_queue,
                     opts,
                     nom_pipe=nom_pipe,
                 ),
@@ -188,6 +201,10 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
             logger.debug("Stopping progress reporter")
             progress_task.cancel()
             await progress_task
+
+        # All workers are done; stop the result consumer.
+        result_queue.put_nowait(None)
+        await dequeue_task
 
         for task in tasks:
             assert task.done(), f"Task {task.get_name()} is not done"

--- a/nix_fast_build/build.py
+++ b/nix_fast_build/build.py
@@ -3,6 +3,7 @@ import contextlib
 import logging
 import os
 import shlex
+import sys
 from asyncio import Queue
 from asyncio.subprocess import Process
 from collections.abc import AsyncIterator, Callable, Coroutine
@@ -96,7 +97,7 @@ class Build:
         )
         cmd = maybe_remote(cmd, opts)
         logger.debug("run %s", shlex.join(cmd))
-        proc = await asyncio.create_subprocess_exec(*cmd)
+        proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
         await exit_stack.enter_async_context(ensure_stop(proc, cmd))
         return await proc.wait()
 
@@ -115,7 +116,7 @@ class Build:
             opts,
         )
         logger.debug("run %s", shlex.join(cmd))
-        proc = await asyncio.create_subprocess_exec(*cmd)
+        proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
         return await proc.wait()
 
     async def _query_build_closure(self, opts: Options) -> list[str]:
@@ -183,7 +184,7 @@ class Build:
             opts,
         )
         logger.debug("run %s", shlex.join(cmd))
-        proc = await asyncio.create_subprocess_exec(*cmd)
+        proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
         return await proc.wait()
 
     async def download(self, exit_stack: AsyncExitStack, opts: Options) -> int:
@@ -203,7 +204,9 @@ class Build:
         logger.debug("run %s", shlex.join(cmd))
         env = os.environ.copy()
         env["NIX_SSHOPTS"] = " ".join(opts.remote_ssh_options)
-        proc = await asyncio.create_subprocess_exec(*cmd, env=env)
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, env=env, stdout=sys.stderr.fileno()
+        )
         await exit_stack.enter_async_context(ensure_stop(proc, cmd))
         return await proc.wait()
 

--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -517,9 +517,6 @@ async def parse_args(args: list[str]) -> Options:
     else:
         systems = set(a.systems.split(" "))
 
-    if a.no_nom is False and a.stream_json_lines:
-        parser.error("--stream-json-lines implies --no-nom")
-
     return Options(
         nix_bin=nix_bin,
         nix_eval_jobs_bin=nix_eval_jobs_bin,

--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -55,6 +55,7 @@ class Options:
     download: bool = True
     no_link: bool = False
     out_link: str = "result"
+    stream_json_lines: bool = False
     result_format: ResultFormat = ResultFormat.JSON
     result_file: Path | None = None
     override_inputs: list[list[str]] = field(default_factory=list)
@@ -371,6 +372,12 @@ async def parse_args(args: list[str]) -> Options:
         help="Format of the build result file",
     )
     parser.add_argument(
+        "--stream-json-lines",
+        action="store_true",
+        default=False,
+        help="Stream results to standard output as JSON Lines",
+    )
+    parser.add_argument(
         "--override-input",
         action="append",
         nargs=2,
@@ -493,7 +500,9 @@ async def parse_args(args: list[str]) -> Options:
     if a.max_jobs is None:
         a.max_jobs = int(nix_config.get("max-jobs", 0))
     if a.no_nom is None:
-        if a.remote:
+        if a.stream_json_lines:
+            a.no_nom = True
+        elif a.remote:
             # only if we have an official binary cache, otherwise we need to build ghc...
             a.no_nom = nix_config.get("system", "") not in [
                 "aarch64-darwin",
@@ -507,6 +516,9 @@ async def parse_args(args: list[str]) -> Options:
         systems = {nix_config.get("system", "")}
     else:
         systems = set(a.systems.split(" "))
+
+    if a.no_nom is False and a.stream_json_lines:
+        parser.error("--stream-json-lines implies --no-nom")
 
     return Options(
         nix_bin=nix_bin,
@@ -540,6 +552,7 @@ async def parse_args(args: list[str]) -> Options:
         store=a.store,
         no_link=a.no_link or bool(a.store),
         out_link=a.out_link,
+        stream_json_lines=a.stream_json_lines,
         result_format=ResultFormat[a.result_format.upper()],
         result_file=a.result_file,
         override_inputs=a.override_input or [],

--- a/nix_fast_build/processes.py
+++ b/nix_fast_build/processes.py
@@ -59,7 +59,7 @@ async def remote_temp_dir(opts: Options) -> AsyncIterator[Path]:
     finally:
         cmd = [*ssh_cmd, "rm", "-rf", tempdir]
         logger.info("run %s", shlex.join(cmd))
-        proc = await asyncio.create_subprocess_exec(*cmd)
+        proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
         await proc.wait()
 
 
@@ -169,7 +169,7 @@ async def run_cachix_daemon(
         ],
         opts,
     )
-    proc = await asyncio.create_subprocess_exec(*cmd)
+    proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
     try:
         await exit_stack.enter_async_context(ensure_stop(proc, cmd))
         while True:
@@ -196,6 +196,6 @@ async def run_cachix_daemon_stop(
         ],
         opts,
     )
-    proc = await asyncio.create_subprocess_exec(*cmd)
+    proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
     await exit_stack.enter_async_context(ensure_stop(proc, cmd))
     return await proc.wait()

--- a/nix_fast_build/processes.py
+++ b/nix_fast_build/processes.py
@@ -4,6 +4,7 @@ import logging
 import shlex
 import signal
 import subprocess
+import sys
 from asyncio.subprocess import Process
 from collections.abc import AsyncIterator
 from contextlib import AsyncExitStack, asynccontextmanager
@@ -32,7 +33,10 @@ async def ensure_stop(
                 try:
                     await asyncio.wait_for(proc.wait(), timeout=wait_timeout)
                 except TimeoutError:
-                    print(f"Failed to stop process {shlex.join(cmd)}. Killing it.")
+                    print(
+                        f"Failed to stop process {shlex.join(cmd)}. Killing it.",
+                        file=sys.stderr,
+                    )
                     proc.kill()
                     await proc.wait()
 

--- a/nix_fast_build/report.py
+++ b/nix_fast_build/report.py
@@ -224,19 +224,7 @@ def capitalize_first_letter(s: str) -> str:
 
 def dump_json(file: IO[str], results: list[Result]) -> None:
     json.dump(
-        {
-            "results": [
-                {
-                    "type": r.result_type.name,
-                    "attr": r.attr,
-                    "success": r.success,
-                    "duration": r.duration,
-                    "error": r.error,
-                    **({"outputs": r.outputs} if r.outputs is not None else {}),
-                }
-                for r in results
-            ]
-        },
+        {"results": [r.as_dict() for r in results]},
         file,
         indent=2,
         sort_keys=True,

--- a/nix_fast_build/results.py
+++ b/nix_fast_build/results.py
@@ -22,6 +22,16 @@ class Result:
     log_output: str | None = None
     outputs: dict[str, str] | None = None
 
+    def as_dict(self) -> dict:
+        return {
+            "type": self.result_type.name,
+            "attr": self.attr,
+            "success": self.success,
+            "duration": self.duration,
+            "error": self.error,
+            **({"outputs": self.outputs} if self.outputs is not None else {}),
+        }
+
 
 @dataclass
 class Summary:

--- a/nix_fast_build/workers.py
+++ b/nix_fast_build/workers.py
@@ -202,7 +202,9 @@ async def run_niks3_upload(
                 opts,
             )
             logger.debug("run %s", shlex.join(cmd))
-            proc = await asyncio.create_subprocess_exec(*cmd, env=env)
+            proc = await asyncio.create_subprocess_exec(
+                *cmd, env=env, stdout=sys.stderr.fileno()
+            )
             rc = await proc.wait()
             duration = timeit.default_timer() - start_time
 

--- a/nix_fast_build/workers.py
+++ b/nix_fast_build/workers.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import sys
 import timeit
+from asyncio import Queue
 from asyncio.subprocess import Process
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
@@ -26,7 +27,7 @@ async def run_evaluation(
     eval_proc: Process,
     build_queue: JobQueue,
     upload_queue: BuildQueue | None,
-    results: list[Result],
+    result_queue: "Queue[Result | None]",
     opts: Options,
 ) -> int:
     assert eval_proc.stdout
@@ -43,7 +44,7 @@ async def run_evaluation(
             raise Error(msg) from e
         error = job.get("error")
         attr = job.get("attr", "unknown-attribute")
-        results.append(
+        await result_queue.put(
             Result(
                 result_type=ResultType.EVAL,
                 attr=attr,
@@ -83,7 +84,7 @@ async def run_builds(
     build_output: IO,
     build_queue: JobQueue,
     optional_queues: list[BuildQueue],
-    results: list[Result],
+    result_queue: "Queue[Result | None]",
     opts: Options,
     nom_pipe: IO[bytes] | None = None,
 ) -> int:
@@ -108,7 +109,7 @@ async def run_builds(
             build_result = await build.build(
                 stack, build_output, opts, nom_pipe=nom_pipe
             )
-            results.append(
+            await result_queue.put(
                 Result(
                     result_type=ResultType.BUILD,
                     attr=job.attr,
@@ -132,7 +133,7 @@ async def run_builds(
 
 async def run_queue_worker(
     queue: BuildQueue,
-    results: list[Result],
+    result_queue: "Queue[Result | None]",
     result_type: ResultType,
     label: str,
     push: Callable[[Build], Awaitable[int]],
@@ -145,7 +146,7 @@ async def run_queue_worker(
                 return 0
             start_time = timeit.default_timer()
             rc = await push(build)
-            results.append(
+            await result_queue.put(
                 Result(
                     result_type=result_type,
                     attr=build.attr,
@@ -158,7 +159,7 @@ async def run_queue_worker(
 
 async def run_niks3_upload(
     niks3_queue: BuildQueue,
-    results: list[Result],
+    result_queue: "Queue[Result | None]",
     opts: Options,
 ) -> int:
     while True:
@@ -206,16 +207,16 @@ async def run_niks3_upload(
             duration = timeit.default_timer() - start_time
 
             # Record result for each build
-            results.extend(
-                Result(
-                    result_type=ResultType.NIKS3,
-                    attr=build.attr,
-                    success=rc == 0,
-                    duration=duration / len(builds),
-                    error=f"niks3 upload exited with {rc}" if rc != 0 else None,
+            for build in builds:
+                await result_queue.put(
+                    Result(
+                        result_type=ResultType.NIKS3,
+                        attr=build.attr,
+                        success=rc == 0,
+                        duration=duration / len(builds),
+                        error=f"niks3 upload exited with {rc}" if rc != 0 else None,
+                    )
                 )
-                for build in builds
-            )
 
 
 async def report_progress(

--- a/nix_fast_build/workers.py
+++ b/nix_fast_build/workers.py
@@ -98,8 +98,8 @@ async def run_builds(
                 logger.debug("fail-fast: skipping build of %s", next_job.attr)
                 continue
             job = next_job
-            print(f"  building {job.attr}")
-            sys.stdout.flush()
+            print(f"  building {job.attr}", file=sys.stderr)
+            sys.stderr.flush()
             if job.drv_path in drv_paths:
                 continue
             drv_paths.add(job.drv_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,17 @@ def test_build_json() -> None:
         assert rc == 0
 
 
+def test_stream_json_lines(capfd: pytest.CaptureFixture[str]) -> None:
+    rc = cli(["--option", "builders", "", "--stream-json-lines", "--no-nom"])
+    assert rc == 0
+    lines = [line for line in capfd.readouterr().out.splitlines() if line]
+    assert lines
+    results = [json.loads(line) for line in lines]
+    assert any(r["type"] == "BUILD" for r in results)
+    for r in results:
+        assert r["success"] is True
+
+
 def test_reference_lock_file() -> None:
     """--reference-lock-file is forwarded to nix-eval-jobs."""
     # Pointing at the project's own lock file must behave like a normal build.


### PR DESCRIPTION
I'm trying to integrate `nix-fast-build` with a script that sets a GitLab CI commit status and does some other things.I had already started with that with the misunderstanding `nix-fast-build` would support streaming results like `nix-eval-jobs` does.

To prevent anything else from clobbering the JSON output, all other logs and raw print statements are now written to stderr. The same goes for subprocesses for which the standard output is not captured. All this is done regardless of whether the streamd JSON Line output is enabled. 
The only exception is the output related to nix-output-monitor, which is mutually exclusive with the new feature.

Fixes https://github.com/Mic92/nix-fast-build/issues/161 (as long as you're OK with using standard ouput or redirecting it to a file).
IMHO, writing to a pipe should be preferred when streaming the output.