### PR TITLE
flake: add build closures and flake inputs to checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   self-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         nom: ["", "--no-nom"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -30,7 +30,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,12 @@
         imports = [ ./treefmt.nix ];
         systems = officialPlatforms ++ [ "riscv64-linux" ];
         perSystem =
-          { pkgs, self', ... }:
+          {
+            pkgs,
+            self',
+            config,
+            ...
+          }:
           {
             packages.nix-fast-build = pkgs.callPackage ./default.nix {
               # we don't want to compile ghc otherwise
@@ -64,8 +69,24 @@
               let
                 packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages;
                 devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self'.devShells;
+                # Building inputDerivation turns build-time deps into runtime
+                # references, so CI binary caches retain them.
+                closures = lib.mapAttrs' (n: drv: lib.nameValuePair "closure-${n}" drv.inputDerivation) (
+                  packages // devShells // { treefmt = config.treefmt.build.check inputs.self; }
+                );
+                # Flake inputs are fetched, not built, so caches miss them too.
+                # Same for bashInteractive, which nix develop fetches (all
+                # outputs) for its shell.
+                flake-inputs = pkgs.runCommand "flake-inputs" { } ''
+                  printf '%s\n' ${
+                    lib.concatMapStringsSep " " toString (
+                      lib.attrValues (lib.filterAttrs (_: lib.isAttrs) inputs)
+                      ++ map (o: pkgs.bashInteractive.${o}) pkgs.bashInteractive.outputs
+                    )
+                  } > $out
+                '';
               in
-              packages // devShells;
+              packages // devShells // closures // { closure-flake-inputs = flake-inputs; };
           };
       }
     );

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -9,13 +9,13 @@
         # Used to find the project root
         projectRootFile = ".git/config";
 
-        flakeCheck = pkgs.stdenv.hostPlatform.system != "riscv64-linux";
-
         programs.deno.enable = pkgs.lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.deno;
         programs.mypy.enable = true;
         programs.mypy.directories."root".directory = ".";
         programs.deadnix.enable = true;
         programs.nixfmt.enable = true;
+        # Rust rewrite; the Haskell nixfmt cannot bootstrap GHC on riscv64-linux
+        programs.nixfmt.package = pkgs.nixfmt-rs;
         programs.ruff.format = true;
         programs.ruff.check = true;
       };


### PR DESCRIPTION

The CI binary cache only keeps built outputs and their runtime
closure. Build-time deps (git via the treefmt check, stdenv) and
fetched flake inputs like nixpkgs are never referenced by an output,
so every run re-downloads them from cache.nixos.org.

Add inputDerivation of each package, devshell and the treefmt check
plus a derivation referencing all flake inputs as checks, making CI
build and cache these paths.
