### PR TITLE
filter harmless eval-cache SQLite busy errors

### DIFF
--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -102,8 +102,12 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
         renderer; written directly it would corrupt the TTY region."""
         async for raw in read_eval_stderr_lines(eval_jobs.stderr):
             line = sanitize_line(raw.decode(errors="replace").rstrip("\r\n"))
-            if line:
-                renderer.log_line(line)
+            if not line:
+                continue
+            # nix already retries this internally (hence "ignored"); drop it
+            if "error (ignored): SQLite database" in line and "is busy" in line:
+                continue
+            renderer.log_line(line)
 
     cachix_socket_path: Path | None = None
     if opts.cachix_cache:


### PR DESCRIPTION

When many eval workers hit the shared eval-cache SQLite database
concurrently, nix emits 'error (ignored): ... is busy' lines. nix
retries internally and the errors are harmless, but they spam the
output. Drop these lines from the eval stderr stream.

Closes #350
