### PR TITLE
filter eval-cache SQLite busy errors on interactive TTY

### DIFF
--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -28,7 +28,7 @@ from .report import (
 )
 from .results import Result, ResultType, Summary
 from .sources import upload_sources
-from .term import fold_markers, sanitize_line, want_color
+from .term import fold_markers, is_ignored_eval_line, sanitize_line, want_color
 from .tty_renderer import TTYRenderer
 from .workers import (
     report_progress,
@@ -104,8 +104,7 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
             line = sanitize_line(raw.decode(errors="replace").rstrip("\r\n"))
             if not line:
                 continue
-            # nix already retries this internally (hence "ignored"); drop it
-            if "error (ignored): SQLite database" in line and "is busy" in line:
+            if is_ignored_eval_line(line):
                 continue
             renderer.log_line(line)
 

--- a/nix_fast_build/term.py
+++ b/nix_fast_build/term.py
@@ -18,6 +18,21 @@ _STRAY_ESC_RE = re.compile(r"\x1b(?!\[[0-?]*[ -/]*m)")
 _TRAILING_PARTIAL_SGR_RE = re.compile(r"\x1b[^m]*$")
 
 
+def strip_ansi(s: str) -> str:
+    """Remove all ANSI escape sequences (for content matching, not display)."""
+    return ANSI_RE.sub("", s)
+
+
+def is_ignored_eval_line(line: str) -> bool:
+    """True for the harmless eval-cache "SQLite database is busy" error.
+
+    nix retries it internally (hence "ignored") and colors the prefix on a
+    TTY, so match against the ANSI-stripped text.
+    """
+    plain = strip_ansi(line)
+    return "error (ignored): SQLite database" in plain and "is busy" in plain
+
+
 def sanitize_line(s: str) -> str:
     """Make one captured log line safe to re-emit.
 

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -5,9 +5,19 @@ import pytest
 from nix_fast_build.term import (
     MAX_LINE_LEN,
     fold_markers,
+    is_ignored_eval_line,
     sanitize_line,
     want_color,
 )
+
+
+def test_is_ignored_eval_line_colored() -> None:
+    # nix colors "error (ignored):" on a TTY, which broke the plain match.
+    line = sanitize_line(
+        "\x1b[31;1merror (ignored):\x1b[0m SQLite database '/cache/x.sqlite' is busy"
+    )
+    assert is_ignored_eval_line(line)
+    assert not is_ignored_eval_line("evaluation warning: 'system' has been renamed")
 
 
 def test_sanitize_passthrough() -> None:


### PR DESCRIPTION

The "error (ignored): SQLite database ... is busy" filter matched a plain
substring, but on an interactive TTY nix wraps "error (ignored):" in ANSI
color codes. The reset sequence lands between the colon and " SQLite", so
the substring never matched and the noise leaked through.

Strip ANSI before matching and move the predicate into a tested helper.


