### PR TITLE
ci: switch to Mic92/hestia@v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
       - uses: NixOS/nix-installer-action@main
-      - uses: Mic92/hestia/action@main
+      - uses: Mic92/hestia@v1
       - name: Self-test
         run: nix shell --inputs-from . nixpkgs#coreutils -c timeout --verbose 600 nix run .
 
@@ -37,7 +37,7 @@ jobs:
           # Nix Flakes doesn't work on shallow clones
           fetch-depth: 0
       - uses: NixOS/nix-installer-action@main
-      - uses: Mic92/hestia/action@main
+      - uses: Mic92/hestia@v1
       - name: Install nix-eval-jobs for remote test
         run: nix profile install --inputs-from . nixpkgs#nix-eval-jobs
       - run: command -v nix-eval-jobs && nix-eval-jobs --help


### PR DESCRIPTION
Hestia [v1.0](https://github.com/Mic92/hestia/releases/tag/v1.0.2) moved action.yml to the repo root, so the path shortens from `Mic92/hestia/action@main` to `Mic92/hestia@v1`. Tracks the floating major tag for automatic 1.x updates.