### PR TITLE
feat: passthrough arguments

### DIFF
--- a/nix_fast_build/build.py
+++ b/nix_fast_build/build.py
@@ -273,6 +273,7 @@ async def nix_build(
             opts.out_link + "-" + attr,
         ]
 
+    args += opts.build_args
     args = maybe_remote(args, opts)
     logger.debug("run %s", shlex.join(args))
 

--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -63,6 +63,8 @@ class Options:
     select_expr: str | None = None
     fail_fast: bool = False
     reference_lock_file: str | None = None
+    eval_args: list[str] = field(default_factory=list)
+    build_args: list[str] = field(default_factory=list)
 
     cachix_cache: str | None = None
 
@@ -420,6 +422,23 @@ async def parse_args(args: list[str]) -> Options:
         default=False,
         help="Stop as soon as any build or evaluation fails, instead of continuing with remaining builds.",
     )
+    parser.add_argument(
+        "--eval-args",
+        type=str,
+        default=None,
+        help="Extra arguments to pass to nix-eval-jobs (split using shlex)",
+    )
+    parser.add_argument(
+        "--build-args",
+        type=str,
+        default=None,
+        help="Extra arguments to pass to nix build (split using shlex)",
+    )
+    parser.add_argument(
+        "build_remainder",
+        nargs="*",
+        help="Extra arguments to pass to nix build (passed after --)",
+    )
 
     a = parser.parse_args(args)
 
@@ -560,4 +579,6 @@ async def parse_args(args: list[str]) -> Options:
         select_expr=a.select,
         reference_lock_file=a.reference_lock_file,
         fail_fast=a.fail_fast,
+        eval_args=shlex.split(a.eval_args or ""),
+        build_args=shlex.split(a.build_args or "") + a.build_remainder,
     )

--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -11,6 +11,10 @@ from pathlib import Path
 from .errors import Error
 
 
+def _deprecated_help(command: str) -> str:
+    return f"DEPRECATED: replaced by {command} | "
+
+
 def _nix_command(nix_bin: list[str], args: list[str]) -> list[str]:
     return [*nix_bin, "--experimental-features", "nix-command flakes", *args]
 
@@ -228,13 +232,17 @@ async def parse_args(args: list[str]) -> Options:
         "--impure",
         action="store_true",
         default=False,
-        help="Allow impure expressions (default in --file mode)",
+        deprecated=True,
+        help=_deprecated_help("--eval-args=--impure")
+        + "Allow impure expressions (default in --file mode)",
     )
     parser.add_argument(
         "--pure",
         action="store_true",
         default=False,
-        help="Enforce pure evaluation in --file mode (overrides the default impure behavior)",
+        deprecated=True,
+        help=_deprecated_help("--eval-args=--pure")
+        + "Enforce pure evaluation in --file mode (overrides the default impure behavior)",
     )
 
     parser.add_argument(
@@ -246,11 +254,12 @@ async def parse_args(args: list[str]) -> Options:
     )
     parser.add_argument(
         "--option",
-        help="Nix option to set",
+        help=_deprecated_help("--eval-args/--build-args") + "Nix option to set",
         action="append",
         nargs=2,
         metavar=("name", "value"),
         default=[],
+        deprecated=True,
     )
     parser.add_argument(
         "--remote-ssh-option",
@@ -315,14 +324,18 @@ async def parse_args(args: list[str]) -> Options:
     )
     parser.add_argument(
         "--no-link",
-        help="Do not create an out-link for builds (default: false)",
+        help=_deprecated_help("--build-args=--no-link")
+        + "Do not create an out-link for builds (default: false)",
         action="store_true",
         default=False,
+        deprecated=True,
     )
     parser.add_argument(
         "--out-link",
-        help="Name of the out-link for builds (default: result)",
+        help=_deprecated_help("--build-args=--out-link")
+        + "Name of the out-link for builds (default: result)",
         default="result",
+        deprecated=True,
     )
     parser.add_argument(
         "--store",
@@ -396,7 +409,9 @@ async def parse_args(args: list[str]) -> Options:
         action="append",
         nargs=2,
         metavar=("input_path", "flake_url"),
-        help="Override a specific flake input (e.g. `dwarffs/nixpkgs`).",
+        help=_deprecated_help("--eval-args=--override-input")
+        + "Override a specific flake input (e.g. `dwarffs/nixpkgs`).",
+        deprecated=True,
     )
     parser.add_argument(
         "--select",
@@ -414,7 +429,9 @@ async def parse_args(args: list[str]) -> Options:
         "--reference-lock-file",
         type=str,
         default=None,
-        help="Read the given lock file instead of `flake.lock` within the top-level flake.",
+        help=_deprecated_help("--eval-args=--reference-lock-file")
+        + "Read the given lock file instead of `flake.lock` within the top-level flake.",
+        deprecated=True,
     )
     parser.add_argument(
         "--fail-fast",

--- a/nix_fast_build/processes.py
+++ b/nix_fast_build/processes.py
@@ -106,6 +106,7 @@ async def nix_eval_jobs(
         "--workers",
         str(opts.eval_workers),
         *opts.options,
+        *opts.eval_args,
     ]
     if opts.impure:
         args.append("--impure")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ exclude = '''
 '''
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.13"
 warn_redundant_casts = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
@@ -68,7 +68,7 @@ ignore_missing_imports = true
 pythonpath = [ "." ]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py313"
 line-length = 88
 lint.select = ["ALL"]
 # White-box tests may exercise private helpers directly.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -269,3 +269,25 @@ def test_store_ssh_ng(sshd: Sshd, monkeypatch: pytest.MonkeyPatch) -> None:
         ]
     )
     assert rc == 0
+
+
+def test_passthrough_parsing() -> None:
+    # 1. Test only --eval-args
+    opts = asyncio.run(parse_args(["--eval-args", "--impure --show-trace"]))
+    assert opts.eval_args == ["--impure", "--show-trace"]
+    assert opts.build_args == []
+
+    # 2. Test only --build-args
+    opts = asyncio.run(parse_args(["--build-args", "--dry-run --repair"]))
+    assert opts.build_args == ["--dry-run", "--repair"]
+    assert opts.eval_args == []
+
+    # 3. Test only -- remainder
+    opts = asyncio.run(parse_args(["--", "--dry-run", "--repair"]))
+    assert opts.build_args == ["--dry-run", "--repair"]
+    assert opts.eval_args == []
+
+    # 4. Test both --build-args and -- remainder combined
+    opts = asyncio.run(parse_args(["--build-args=--dry-run", "--", "--repair"]))
+    assert opts.build_args == ["--dry-run", "--repair"]
+    assert opts.eval_args == []


### PR DESCRIPTION
CLOSES: #375

Adds passthrough arguments

- `--eval-args` to `nix-eval-jobs`
- `--build-args` / `--` to `nix build`

### Examples

Old:
```bash
nix-fast-build --impure --no-link --out-link result-my-app
```

New:
```bash
nix-fast-build --eval-args "--impure" --build-args "--no-link --out-link result-my-app"
```
Or:
```bash
nix-fast-build --eval-args "--impure" -- --no-link --out-link result-my-app
```
