### PR TITLE
Fix process termination logic bug in ensure_stop to fully fix issue #350

### DIFF
--- a/nix_fast_build/processes.py
+++ b/nix_fast_build/processes.py
@@ -30,7 +30,7 @@ async def ensure_stop(
     try:
         yield proc
     finally:
-        if proc.returncode is not None:
+        if proc.returncode is None:
             with contextlib.suppress(ProcessLookupError):
                 proc.send_signal(signal_no)
                 try:


### PR DESCRIPTION
I noticed that issue #350 was still occurring for me, despite #364.

I'm a bit of an ignorant noob [around this kind of thing anyway], but my AI (Antigravity) had a closer look for me, and suggested this:

> It's because of a inverted logic check in ensure_stop. 
> When `proc.returncode` is **not** `None`, the process has already completed and exited, so sending `SIGTERM`/`SIGKILL` is a no-op. When `proc.returncode` is `None`, the process is active and running, but the is `not None` guard skips signal delivery entirely!
> As a result, sub-processes like `nix-eval-jobs` were not being stopped when exiting early. Changing `if proc.returncode is not None:` to `if proc.returncode is None:` resolves the issue.

@Mic92 I'll leave it up to you if you want to merge this PR, or prefer fixing this otherwise?