### PR TITLE
sources: materialise flake source with 'nix flake prefetch' before copy

### DIFF
--- a/nix_fast_build/sources.py
+++ b/nix_fast_build/sources.py
@@ -57,7 +57,9 @@ def upload_sources(opts: Options) -> str:
             return url
         if not has_path_inputs:
             # Just copy the flake to the remote machine, we can substitute other inputs there.
-            path = flake_data["path"]
+            path = _run_json(
+                opts.nix_command(["flake", "prefetch", "--json", opts.flake_url])
+            )["storePath"]
             env = os.environ.copy()
             env["NIX_SSHOPTS"] = " ".join(opts.remote_ssh_options)
             assert opts.remote_url


### PR DESCRIPTION

Since Nix 2.35, 'nix flake metadata' only computes the flake's store
path lazily without materialising it in the local store. The fast
upload path then fails with:

  error: path '/nix/store/...-source' is required, but there is no
  substituter that can build it

Use 'nix flake prefetch --json' instead, which fetches the source into
the local store and reports its store path. This keeps the fast path
(only the flake itself is copied and inputs are substituted on the remote)
instead of falling back to 'nix flake archive', which would upload all
inputs.

Fixes #389
