### PR TITLE
build: drop result symlinks by default, keep gcroots only for the run

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ nix run github:Mic92/nix-fast-build -- --store ssh-ng://youruser@yoursshhostname
 ```
 
 Unlike `--remote` (which runs the whole pipeline over SSH), `--store` uses the
-Nix store protocol only. It implies `--no-link` since outputs stay in the remote
-store. It cannot be combined with `--remote`, `--copy-to`, or upload flags.
+Nix store protocol only. Outputs stay in the remote store, so `--out-link`
+cannot be used. It cannot be combined with `--remote`, `--copy-to`, or upload
+flags.
 
 ## Build Output
 
@@ -401,11 +402,14 @@ options:
   --systems SYSTEMS     Space-separated list of systems to build for (default:
                         current system)
   --retries RETRIES     Number of times to retry failed builds
-  --no-link             Do not create an out-link for builds (default: false)
-  --out-link OUT_LINK   Name of the out-link for builds (default: result)
+  --no-link             Deprecated no-op: not creating out-links is now the
+                        default
+  --out-link OUT_LINK   Create persistent result symlinks with this name
+                        prefix (e.g. 'result'). By default builds are only gc-
+                        rooted for the duration of the run.
   --store STORE         Nix store URL to build against (e.g. ssh-ng://host).
                         Evaluation stays local; only builds are dispatched.
-                        Implies --no-link.
+                        Conflicts with --out-link.
   --remote REMOTE       Remote machine to build on
   --always-upload-source
                         Always upload sources to remote machine. This is

--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -86,6 +86,7 @@ def start_renderer(stack: AsyncExitStack, opts: Options) -> CIRenderer | TTYRend
 async def run(stack: AsyncExitStack, opts: Options) -> int:
     if opts.remote:
         tmp_dir = await stack.enter_async_context(remote_temp_dir(opts))
+        opts.download_gcroot_dir = Path(stack.enter_context(TemporaryDirectory()))
     else:
         tmp_dir = Path(stack.enter_context(TemporaryDirectory()))
 

--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -89,6 +89,8 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
     else:
         tmp_dir = Path(stack.enter_context(TemporaryDirectory()))
 
+    opts.build_gcroot_dir = tmp_dir
+
     # Renderer first: from here on all terminal output (including log
     # records and eval stderr) must go through it.
     renderer = start_renderer(stack, opts)

--- a/nix_fast_build/build.py
+++ b/nix_fast_build/build.py
@@ -265,13 +265,14 @@ async def nix_build(
         ["build", f"{installable}^*", "--keep-going", *opts.options, *opts.store_args]
     )
     args += ["--log-format", "internal-json", "-v"]
-    if opts.no_link:
+    if opts.store is not None:
+        # outputs live in a remote store, a local out-link would dangle
         args += ["--no-link"]
+    elif opts.out_link is not None:
+        args += ["--out-link", opts.out_link + "-" + attr]
     else:
-        args += [
-            "--out-link",
-            opts.out_link + "-" + attr,
-        ]
+        assert opts.build_gcroot_dir is not None
+        args += ["--out-link", str(opts.build_gcroot_dir / f"result-{attr}")]
 
     args = maybe_remote(args, opts)
     logger.debug("run %s", shlex.join(args))

--- a/nix_fast_build/build.py
+++ b/nix_fast_build/build.py
@@ -201,6 +201,16 @@ class Build:
         proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
         return await proc.wait()
 
+    def out_link_args(self, opts: Options) -> list[str]:
+        if opts.out_link is not None:
+            return ["--out-link", opts.out_link + "-" + self.attr]
+        if opts.download_gcroot_dir is not None:
+            return [
+                "--out-link",
+                str(opts.download_gcroot_dir / f"result-{self.attr}"),
+            ]
+        return []
+
     async def download(self, exit_stack: AsyncExitStack, opts: Options) -> int:
         if not opts.remote_url or not opts.download or not self.outputs:
             return 0
@@ -212,6 +222,7 @@ class Build:
                 "--no-check-sigs",
                 "--from",
                 opts.remote_url,
+                *self.out_link_args(opts),
                 *list(self.outputs.values()),
             ]
         )
@@ -268,7 +279,8 @@ async def nix_build(
     if opts.store is not None:
         # outputs live in a remote store, a local out-link would dangle
         args += ["--no-link"]
-    elif opts.out_link is not None:
+    elif opts.out_link is not None and opts.remote is None:
+        # with --remote the persistent link is created locally on download
         args += ["--out-link", opts.out_link + "-" + attr]
     else:
         assert opts.build_gcroot_dir is not None

--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -60,6 +60,8 @@ class Options:
     out_link: str | None = None
     # Set at runtime; roots vanish with the run's temp dir
     build_gcroot_dir: Path | None = None
+    # Local counterpart for --remote: roots downloaded outputs
+    download_gcroot_dir: Path | None = None
     stream_json_lines: bool = False
     result_format: ResultFormat = ResultFormat.JSON
     result_file: Path | None = None

--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import enum
 import json
+import logging
 import multiprocessing
 import os
 import shlex
@@ -9,6 +10,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from .errors import Error
+
+logger = logging.getLogger(__name__)
 
 
 def _nix_command(nix_bin: list[str], args: list[str]) -> list[str]:
@@ -54,8 +57,9 @@ class Options:
     no_fold: bool = False
     stall_timeout: float = 300.0
     download: bool = True
-    no_link: bool = False
-    out_link: str = "result"
+    out_link: str | None = None
+    # Set at runtime; roots vanish with the run's temp dir
+    build_gcroot_dir: Path | None = None
     stream_json_lines: bool = False
     result_format: ResultFormat = ResultFormat.JSON
     result_file: Path | None = None
@@ -313,20 +317,21 @@ async def parse_args(args: list[str]) -> Options:
     )
     parser.add_argument(
         "--no-link",
-        help="Do not create an out-link for builds (default: false)",
+        help="Deprecated no-op: not creating out-links is now the default",
         action="store_true",
         default=False,
     )
     parser.add_argument(
         "--out-link",
-        help="Name of the out-link for builds (default: result)",
-        default="result",
+        help="Create persistent result symlinks with this name prefix (e.g. 'result'). "
+        "By default builds are only gc-rooted for the duration of the run.",
+        default=None,
     )
     parser.add_argument(
         "--store",
         type=str,
         help="Nix store URL to build against (e.g. ssh-ng://host). "
-        "Evaluation stays local; only builds are dispatched. Implies --no-link.",
+        "Evaluation stays local; only builds are dispatched. Conflicts with --out-link.",
     )
     parser.add_argument(
         "--remote",
@@ -435,13 +440,19 @@ async def parse_args(args: list[str]) -> Options:
             (a.cachix_cache, "--cachix-cache"),
             (a.attic_cache, "--attic-cache"),
             (a.niks3_server, "--niks3-server"),
-            (a.out_link != "result", "--out-link"),
+            (a.out_link is not None, "--out-link"),
         ]
         for value, flag in conflicts:
             if value:
                 parser.error(f"{flag} cannot be used with --store")
         if any(name in ("store", "eval-store") for name, _ in a.option):
             parser.error("--option store/eval-store conflicts with --store")
+
+    if a.no_link:
+        logger.warning(
+            "--no-link is deprecated and has no effect: "
+            "not creating out-links is now the default"
+        )
 
     # Validate: --remote is not supported in non-flake mode
     if eval_mode == EvalMode.EXPR and a.remote:
@@ -551,7 +562,6 @@ async def parse_args(args: list[str]) -> Options:
         attic_push_build_closure=a.attic_push_build_closure,
         niks3_server=a.niks3_server,
         store=a.store,
-        no_link=a.no_link or bool(a.store),
         out_link=a.out_link,
         stream_json_lines=a.stream_json_lines,
         result_format=ResultFormat[a.result_format.upper()],

--- a/tests/root.py
+++ b/tests/root.py
@@ -3,15 +3,6 @@ from pathlib import Path
 import pytest
 
 TEST_ROOT = Path(__file__).parent.resolve()
-PROJECT_ROOT = TEST_ROOT.parent
-
-
-@pytest.fixture(scope="session")
-def project_root() -> Path:
-    """
-    Root directory of the tests
-    """
-    return PROJECT_ROOT
 
 
 @pytest.fixture(scope="session")

--- a/tests/sshd.py
+++ b/tests/sshd.py
@@ -5,7 +5,6 @@ import time
 from collections.abc import Iterator
 from pathlib import Path
 from sys import platform
-from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -28,52 +27,54 @@ class SshdConfig:
 
 
 @pytest.fixture(scope="session")
-def sshd_config(project_root: Path, test_root: Path) -> Iterator[SshdConfig]:
-    # FIXME, if any parent of `project_root` is world-writable than sshd will refuse it.
-    with TemporaryDirectory(dir=project_root) as _dir:
-        directory = Path(_dir)
-        host_key = directory / "host_ssh_host_ed25519_key"
+def sshd_config(
+    tmp_path_factory: pytest.TempPathFactory, test_root: Path
+) -> SshdConfig:
+    directory = tmp_path_factory.mktemp("sshd")
+    host_key = directory / "host_ssh_host_ed25519_key"
+    subprocess.run(
+        [
+            "ssh-keygen",
+            "-t",
+            "ed25519",
+            "-f",
+            host_key,
+            "-N",
+            "",
+        ],
+        check=True,
+    )
+
+    sshd_config = directory / "sshd_config"
+    sshd_config.write_text(
+        f"""
+    HostKey {host_key}
+    # tmp_path lives under a world-writable /tmp, skip the ownership check
+    StrictModes no
+    LogLevel DEBUG3
+    # In the nix build sandbox we don't get any meaningful PATH after login
+    SetEnv PATH={os.environ.get("PATH", "")}
+    MaxStartups 64:30:256
+    AuthorizedKeysFile {host_key}.pub
+    """
+    )
+
+    lib_path = None
+    if platform == "linux":
+        # This enforces a login shell by overriding the login shell of `getpwnam(3)`
+        lib_path = str(directory / "libgetpwnam-preload.so")
         subprocess.run(
             [
-                "ssh-keygen",
-                "-t",
-                "ed25519",
-                "-f",
-                host_key,
-                "-N",
-                "",
+                os.environ.get("CC", "cc"),
+                "-shared",
+                "-o",
+                lib_path,
+                str(test_root / "getpwnam-preload.c"),
             ],
             check=True,
         )
 
-        sshd_config = directory / "sshd_config"
-        sshd_config.write_text(
-            f"""
-        HostKey {host_key}
-        LogLevel DEBUG3
-        # In the nix build sandbox we don't get any meaningful PATH after login
-        SetEnv PATH={os.environ.get("PATH", "")}
-        MaxStartups 64:30:256
-        AuthorizedKeysFile {host_key}.pub
-        """
-        )
-
-        lib_path = None
-        if platform == "linux":
-            # This enforces a login shell by overriding the login shell of `getpwnam(3)`
-            lib_path = str(directory / "libgetpwnam-preload.so")
-            subprocess.run(
-                [
-                    os.environ.get("CC", "cc"),
-                    "-shared",
-                    "-o",
-                    lib_path,
-                    str(test_root / "getpwnam-preload.c"),
-                ],
-                check=True,
-            )
-
-        yield SshdConfig(str(sshd_config), str(host_key), lib_path)
+    return SshdConfig(str(sshd_config), str(host_key), lib_path)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,6 +202,26 @@ def test_flake_and_expr_mutually_exclusive() -> None:
     assert e.value.code == 2
 
 
+def remote_args(sshd: Sshd) -> list[str]:
+    login = pwd.getpwuid(os.getuid()).pw_name
+    return [
+        "--remote",
+        f"{login}@127.0.0.1",
+        "--remote-ssh-option",
+        "Port",
+        str(sshd.port),
+        "--remote-ssh-option",
+        "IdentityFile",
+        sshd.key,
+        "--remote-ssh-option",
+        "StrictHostKeyChecking",
+        "no",
+        "--remote-ssh-option",
+        "UserKnownHostsFile",
+        "/dev/null",
+    ]
+
+
 def test_remote(sshd: Sshd) -> None:
     login = pwd.getpwuid(os.getuid()).pw_name
     rc = cli(
@@ -226,6 +246,31 @@ def test_remote(sshd: Sshd) -> None:
         ]
     )
     assert rc == 0
+
+
+def test_remote_out_link_creates_local_symlinks(
+    sshd: Sshd, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    flake = TEST_ROOT.parent
+    monkeypatch.chdir(tmp_path)
+    rc = cli(
+        [
+            "--option",
+            "builders",
+            "",
+            "--flake",
+            f"{flake}#checks",
+            "--out-link",
+            "result",
+            *remote_args(sshd),
+        ]
+    )
+    assert rc == 0
+    links = [p for p in tmp_path.iterdir() if p.name.startswith("result-")]
+    assert links
+    for link in links:
+        assert link.is_symlink()
+        assert link.readlink().exists()
 
 
 def test_store_implies_no_link() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -230,7 +230,50 @@ def test_remote(sshd: Sshd) -> None:
 
 def test_store_implies_no_link() -> None:
     opts = asyncio.run(parse_args(["--store", "ssh-ng://x"]))
-    assert opts.no_link is True
+    assert opts.out_link is None
+
+
+def test_default_out_link_is_none() -> None:
+    opts = asyncio.run(parse_args([]))
+    assert opts.out_link is None
+
+
+def test_no_link_is_deprecated_noop() -> None:
+    opts = asyncio.run(parse_args(["--no-link"]))
+    assert opts.out_link is None
+
+
+def test_default_creates_no_result_symlinks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    flake = TEST_ROOT.parent
+    monkeypatch.chdir(tmp_path)
+    rc = cli(["--option", "builders", "", "--flake", f"{flake}#checks"])
+    assert rc == 0
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_out_link_creates_result_symlinks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    flake = TEST_ROOT.parent
+    monkeypatch.chdir(tmp_path)
+    rc = cli(
+        [
+            "--option",
+            "builders",
+            "",
+            "--flake",
+            f"{flake}#checks",
+            "--out-link",
+            "result",
+        ]
+    )
+    assert rc == 0
+    links = [p for p in tmp_path.iterdir() if p.name.startswith("result-")]
+    assert links
+    for link in links:
+        assert link.is_symlink()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -31,7 +31,11 @@ esac
         async with AsyncExitStack() as stack:
             return await build.build(
                 stack,
-                Options(nix_bin=[str(fake_nix)], retries=retries, no_link=True),
+                Options(
+                    nix_bin=[str(fake_nix)],
+                    retries=retries,
+                    build_gcroot_dir=tmp_path,
+                ),
             )
         # Unreachable; mypy can't tell AsyncExitStack never suppresses here.
         raise AssertionError


### PR DESCRIPTION

Persistent result-* symlinks litter the working directory and users had
no way to avoid them without also losing GC protection (--no-link raced
uploads against nix-collect-garbage). Instead, always create the
out-link inside the run's temporary directory: outputs stay rooted until
all builds and uploads finish, then the root disappears with the tmpdir.

--out-link no longer has a default and becomes the opt-in way to get
persistent symlinks. --no-link is kept as a deprecated no-op for
backwards compatibility. --store keeps building with --no-link since a
local out-link would dangle for a remote store.

Fixes #65
