### PR TITLE
Disable client-side remote builders when --store is used

### DIFF
--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -105,8 +105,9 @@ class Options:
         """Extra args to point nix build/log at the build store."""
         if self.store is None:
             return []
-        # --eval-store auto ensures nix finds locally-evaluated .drvs
-        return ["--eval-store", "auto", "--store", self.store]
+        # eval-store auto finds locally-evaluated .drvs; empty builders
+        # keeps the client from dispatching to nix.conf remote builders.
+        return ["--eval-store", "auto", "--store", self.store, "--builders", ""]
 
     @property
     def display_name(self) -> str:
@@ -333,7 +334,8 @@ async def parse_args(args: list[str]) -> Options:
         "--store",
         type=str,
         help="Nix store URL to build against (e.g. ssh-ng://host). "
-        "Evaluation stays local; only builds are dispatched. Conflicts with --out-link.",
+        "Evaluation stays local and only builds are dispatched. "
+        "Implies --builders ''. Conflicts with --out-link.",
     )
     parser.add_argument(
         "--remote",
@@ -447,8 +449,8 @@ async def parse_args(args: list[str]) -> Options:
         for value, flag in conflicts:
             if value:
                 parser.error(f"{flag} cannot be used with --store")
-        if any(name in ("store", "eval-store") for name, _ in a.option):
-            parser.error("--option store/eval-store conflicts with --store")
+        if any(name in ("store", "eval-store", "builders") for name, _ in a.option):
+            parser.error("--option store/eval-store/builders conflicts with --store")
 
     if a.no_link:
         logger.warning(

--- a/nix_fast_build/workers.py
+++ b/nix_fast_build/workers.py
@@ -67,8 +67,12 @@ async def run_evaluation(
         # them for pushing if they are cached locally
         elif cache_status == "cached":
             continue
-        elif cache_status == "local" and upload_queue is not None:
-            upload_queue.put_nowait(Build(attr, job["drvPath"], _job_outputs(job)))
+        elif cache_status == "local":
+            if upload_queue is not None:
+                upload_queue.put_nowait(Build(attr, job["drvPath"], _job_outputs(job)))
+            # already valid locally: build only if a result symlink is wanted
+            if opts.out_link is None:
+                continue
         system = job.get("system")
         if system and system not in opts.systems:
             continue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -278,6 +278,12 @@ def test_store_implies_no_link() -> None:
     assert opts.out_link is None
 
 
+def test_store_disables_local_builders() -> None:
+    opts = asyncio.run(parse_args(["--store", "ssh-ng://x"]))
+    assert "--builders" in opts.store_args
+    assert opts.store_args[opts.store_args.index("--builders") + 1] == ""
+
+
 def test_default_out_link_is_none() -> None:
     opts = asyncio.run(parse_args([]))
     assert opts.out_link is None
@@ -332,6 +338,7 @@ def test_out_link_creates_result_symlinks(
         ["--out-link", "my-result"],
         ["--option", "store", "ssh-ng://y"],
         ["--option", "eval-store", "local"],
+        ["--option", "builders", "ssh://b"],
     ],
 )
 def test_store_conflicts(extra_args: list[str]) -> None:
@@ -347,13 +354,5 @@ def test_store_ssh_ng(sshd: Sshd, monkeypatch: pytest.MonkeyPatch) -> None:
         f"-p {sshd.port} -i {sshd.key} "
         f"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
     )
-    rc = cli(
-        [
-            "--option",
-            "builders",
-            "",
-            "--store",
-            f"ssh-ng://{login}@127.0.0.1",
-        ]
-    )
+    rc = cli(["--store", f"ssh-ng://{login}@127.0.0.1"])
     assert rc == 0

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,59 @@
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any
+
+from nix_fast_build.build import BuildQueue, JobQueue
+from nix_fast_build.options import Options
+from nix_fast_build.workers import run_evaluation
+
+if TYPE_CHECKING:
+    from nix_fast_build.results import Result
+
+
+class FakeEvalProc:
+    def __init__(self, jobs: list[dict[str, Any]]) -> None:
+        self.stdout = self._lines(jobs)
+
+    @staticmethod
+    async def _lines(jobs: list[dict[str, Any]]) -> Any:
+        for job in jobs:
+            yield (json.dumps(job) + "\n").encode()
+
+    async def wait(self) -> int:
+        return 0
+
+
+JOB = {
+    "attr": "foo",
+    "drvPath": "/nix/store/aaa-foo.drv",
+    "outputs": {"out": "/nix/store/aaa-foo"},
+    "system": "x86_64-linux",
+    "cacheStatus": "local",
+}
+
+
+def _eval(opts: Options) -> tuple[JobQueue, BuildQueue]:
+    build_queue: JobQueue = JobQueue()
+    upload_queue: BuildQueue = BuildQueue()
+    result_queue: asyncio.Queue[Result | None] = asyncio.Queue()
+    asyncio.run(
+        run_evaluation(
+            FakeEvalProc([JOB]),  # type: ignore[arg-type]
+            build_queue,
+            upload_queue,
+            result_queue,
+            opts,
+        )
+    )
+    return build_queue, upload_queue
+
+
+def test_local_cache_status_skips_build() -> None:
+    build_queue, upload_queue = _eval(Options(systems={"x86_64-linux"}))
+    assert build_queue.qsize() == 0
+    assert upload_queue.qsize() == 1
+
+
+def test_local_cache_status_builds_when_out_link_requested() -> None:
+    build_queue, _ = _eval(Options(systems={"x86_64-linux"}, out_link="result"))
+    assert build_queue.qsize() == 1


### PR DESCRIPTION

With --store all building happens in the target store, but a client
with remote builders configured in nix.conf could still dispatch
builds through the build hook, bypassing the store and defeating
setups like nixbuild.net's remote-store mode. Pass --builders ""
alongside --store and reject --option builders, consistent with the
existing store/eval-store rejection.

Fixes #367
