### PR TITLE
report outputs, drvPath and cacheStatus in EVAL results

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,10 @@ cat ./result.json
        "duration": 0.0,
        "error": null,
        "success": true,
-       "type": "EVAL"
+       "type": "EVAL",
+       "outputs": {"out": "/nix/store/..."},
+       "drvPath": "/nix/store/...-package-default.drv",
+       "cacheStatus": "notBuilt"
      },
 # ...
 ```
@@ -311,7 +314,7 @@ error, so stdout contains only JSON Lines. This implies `--no-nom`.
 
 ```console
 nix-fast-build --stream-json-lines
-{"type": "EVAL", "attr": "x86_64-linux.package-default", "success": true, "duration": 0.0, "error": null}
+{"type": "EVAL", "attr": "x86_64-linux.package-default", "success": true, "duration": 0.0, "error": null, "outputs": {"out": "/nix/store/..."}, "drvPath": "/nix/store/...drv", "cacheStatus": "notBuilt"}
 {"type": "BUILD", "attr": "x86_64-linux.package-default", "success": true, "duration": 1.2, "error": null, "outputs": {"out": "/nix/store/..."}}
 ```
 

--- a/nix_fast_build/results.py
+++ b/nix_fast_build/results.py
@@ -21,6 +21,8 @@ class Result:
     error: str | None
     log_output: str | None = None
     outputs: dict[str, str] | None = None
+    drv_path: str | None = None
+    cache_status: str | None = None
 
     def as_dict(self) -> dict:
         return {
@@ -30,6 +32,12 @@ class Result:
             "duration": self.duration,
             "error": self.error,
             **({"outputs": self.outputs} if self.outputs is not None else {}),
+            **({"drvPath": self.drv_path} if self.drv_path is not None else {}),
+            **(
+                {"cacheStatus": self.cache_status}
+                if self.cache_status is not None
+                else {}
+            ),
         }
 
 

--- a/nix_fast_build/workers.py
+++ b/nix_fast_build/workers.py
@@ -45,6 +45,10 @@ async def run_evaluation(
             raise Error(msg) from e
         error = job.get("error")
         attr = job.get("attr", "unknown-attribute")
+        cache_status = job.get("cacheStatus")
+        if cache_status is None and job.get("isCached", False):
+            cache_status = "cached"
+        outputs = _job_outputs(job)
         await result_queue.put(
             Result(
                 result_type=ResultType.EVAL,
@@ -53,23 +57,21 @@ async def run_evaluation(
                 # TODO: maybe add this to nix-eval-jobs?
                 duration=0.0,
                 error=error,
+                outputs=outputs or None,
+                drv_path=job.get("drvPath"),
+                cache_status=cache_status,
             )
         )
         if error:
             opts.signal_stop()
             continue
-        cache_status = job.get("cacheStatus")
-        if cache_status is None:
-            # Legacy attribute
-            if job.get("isCached", False):
-                continue
         # Skip remotely cached jobs, but still consider
         # them for pushing if they are cached locally
-        elif cache_status == "cached":
+        if cache_status == "cached":
             continue
-        elif cache_status == "local":
+        if cache_status == "local":
             if upload_queue is not None:
-                upload_queue.put_nowait(Build(attr, job["drvPath"], _job_outputs(job)))
+                upload_queue.put_nowait(Build(attr, job["drvPath"], outputs))
             # already valid locally: build only if a result symlink is wanted
             if opts.out_link is None:
                 continue
@@ -80,7 +82,7 @@ async def run_evaluation(
         if not drv_path:
             msg = f"nix-eval-jobs did not return a drvPath: {line.decode()}"
             raise Error(msg)
-        build_queue.put_nowait(Job(attr, drv_path, _job_outputs(job)))
+        build_queue.put_nowait(Job(attr, drv_path, outputs))
     return await eval_proc.wait()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,11 @@ def test_build_json() -> None:
         for result in build_results:
             assert "outputs" in result
             assert result["outputs"]
+        eval_results = [r for r in data["results"] if r["type"] == "EVAL"]
+        assert eval_results
+        for result in eval_results:
+            assert result["outputs"]
+            assert result["drvPath"].endswith(".drv")
         assert rc == 0
 
 

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -57,3 +57,23 @@ def test_local_cache_status_skips_build() -> None:
 def test_local_cache_status_builds_when_out_link_requested() -> None:
     build_queue, _ = _eval(Options(systems={"x86_64-linux"}, out_link="result"))
     assert build_queue.qsize() == 1
+
+
+def test_eval_result_reports_outputs_and_drv_path() -> None:
+    result_queue: asyncio.Queue[Result | None] = asyncio.Queue()
+    asyncio.run(
+        run_evaluation(
+            FakeEvalProc([{**JOB, "cacheStatus": "cached"}]),  # type: ignore[arg-type]
+            JobQueue(),
+            None,
+            result_queue,
+            Options(systems={"x86_64-linux"}),
+        )
+    )
+    result = result_queue.get_nowait()
+    assert result is not None
+    data = result.as_dict()
+    assert data["type"] == "EVAL"
+    assert data["outputs"] == {"out": "/nix/store/aaa-foo"}
+    assert data["drvPath"] == "/nix/store/aaa-foo.drv"
+    assert data["cacheStatus"] == "cached"


### PR DESCRIPTION
With --skip-cached, attributes that are already cached never produce a
BUILD result, so consumers of --result-file/--stream-json-lines had no
way to learn their store paths short of --out-link, which forces a
build. Forward the paths nix-eval-jobs already reports on the EVAL
result so every evaluated attribute exposes them.

Fixes #397