### PR TITLE
bump version 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "nix-fast-build"
 description = "Evaluate and build in parallel"
-version = "1.7.0"
+version = "2.0.0"
 authors = [{ name = "Jörg Thalheim", email = "joerg@thalheim.io" }]
 license = "MIT"
 classifiers = [


### PR DESCRIPTION
Release 1.7.0 is being renamed to 2.0.0 because dropping nix-output-monitor and no longer creating result symlinks by default are breaking changes.