### PR TITLE
tty_renderer: survive terminal resizes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,7 @@ python3Packages.buildPythonApplication {
   nativeBuildInputs = [
     makeWrapper
     python3Packages.pytest
+    python3Packages.pyte
   ];
   preFixup = ''
     makeWrapperArgs+=(--prefix PATH : ${path})

--- a/nix_fast_build/tty_renderer.py
+++ b/nix_fast_build/tty_renderer.py
@@ -14,6 +14,8 @@ import asyncio
 import contextlib
 import logging
 import os
+import re
+import select
 import shlex
 import shutil
 import signal
@@ -49,6 +51,28 @@ EXTRACT_LINES = 5  # failure extract printed to scrollback
 ARROW_KEYS = {b"A": "k", b"B": "j", b"C": "n", b"D": "p"}
 
 
+def cursor_row(out: IO[str], rows: int) -> int:
+    """Current cursor row via a CPR query, so the live region can start
+    right below the shell prompt instead of at the bottom of the screen."""
+    if not (sys.stdin.isatty() and out.isatty()):
+        return rows
+    fd = sys.stdin.fileno()
+    saved = termios.tcgetattr(fd)
+    try:
+        tty.setcbreak(fd)
+        out.write(f"{CSI}6n")
+        out.flush()
+        reply = ""
+        while not reply.endswith("R"):
+            if not select.select([fd], [], [], 0.2)[0]:
+                return rows
+            reply += os.read(fd, 32).decode(errors="replace")
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+    match = re.search(r"\[(\d+);\d+R", reply)
+    return int(match.group(1)) if match else rows
+
+
 class DisplayLogHandler(logging.Handler):
     """Routes log records through the display.
 
@@ -71,18 +95,33 @@ class Mode(Enum):
 
 
 class Display:
-    """Owns the terminal: permanent scrollback lines + ephemeral region.
+    """Scrollback for permanent lines plus a live region redrawn in place.
 
-    Flicker avoidance: every update is composed into one buffer and emitted
-    with a single write, wrapped in the synchronized-output escape (DEC 2026)
-    so capable terminals paint it atomically. Ephemeral lines are overwritten
-    in place with clear-to-EOL instead of erasing the whole region first.
+    The region floats below the last permanent line until the output
+    reaches the bottom; from then on permanent lines scroll inside a
+    DECSTBM margin above it, so wrapped or bursty output cannot corrupt
+    the region by construction. Resizes are detected by polling size()
+    every frame: during a resize nothing is erased, once the size settles
+    the screen is rebuilt from history. Every update is one write wrapped
+    in DEC 2026 so capable terminals paint it atomically.
     """
 
-    def __init__(self, out: IO[str]) -> None:
+    def __init__(
+        self,
+        out: IO[str],
+        size: Callable[[], os.terminal_size] = shutil.get_terminal_size,
+        origin: int = 1,
+    ) -> None:
         self.out = out
-        self.ephemeral_lines = 0
-        self.last_ephemeral: list[str] = []
+        self.size = size
+        self.row = origin  # row the next permanent line goes to
+        self.top = origin  # first row of the drawn region
+        self.margin = 0  # bottom row of the DECSTBM margin, 0 = none
+        self.cols = 0
+        self.rows = 0
+        self.resizing = False  # size changed within the last frame
+        self.history: deque[str] = deque(maxlen=1000)  # for resize rebuild
+        self.last_region: list[str] = []
         self.suspended = False
         self._pending: list[str] = []  # permanent lines queued while suspended
 
@@ -90,42 +129,79 @@ class Display:
         self.out.write(f"{CSI}?2026h{buf}{CSI}?2026l")
         self.out.flush()
 
-    def _compose_ephemeral(self, lines: list[str]) -> str:
-        """Cursor sits below old region; overwrite it line by line."""
-        width = shutil.get_terminal_size().columns
-        buf = f"{CSI}{self.ephemeral_lines}F" if self.ephemeral_lines else ""
-        for line in lines:
-            # Cell-aware clip (CJK/emoji count as 2): an overwide line would
-            # wrap and break the cursor-up math for the whole region.
-            # RESET re-applied because the clip may drop a trailing reset.
-            buf += f"{clip_ansi(line, width)}{RESET}{CSI}K\n"
-        if len(lines) < self.ephemeral_lines:
-            buf += f"{CSI}J"  # old region was taller: drop leftover lines
-        self.ephemeral_lines = len(lines)
-        self.last_ephemeral = lines
-        return buf
+    def frame(self, permanent: list[str], region: list[str]) -> None:
+        """One atomic update: append permanent lines, redraw the region."""
+        cols, rows = self.size()
+        region = region[: max(rows - 2, 1)]
+        limit = rows - len(region)  # last row permanent lines may occupy
+        buf = HIDE_CURSOR
+        self.history.extend(permanent)
+        if (cols, rows) != (self.cols, self.rows):
+            # Resize in progress: absolute rows are unreliable, so release
+            # the margin, erase nothing and skip the region until it settles.
+            buf += f"{CSI}r"
+            self.margin = 0
+            self.resizing = self.rows != 0
+            self.cols, self.rows = cols, rows
+            self.row = min(self.row, rows)
+        elif self.resizing:
+            # Size settled: rebuild the visible screen from history.
+            self.resizing = False
+            buf += f"{CSI}2J{CSI}1;1H"
+            tail = list(self.history)[-(limit - 1) :] if limit > 1 else []
+            buf += "".join(
+                f"{CSI}{i + 1};1H{line}{CSI}K" for i, line in enumerate(tail)
+            )
+            self.row = len(tail) + 1
+            permanent = []
+        if not self.resizing and self.row > limit + 1:
+            # Region grew: scroll the flow area up to make room.
+            buf += self._set_margin(limit)
+            buf += f"{CSI}{limit};1H" + "\n" * (self.row - limit - 1)
+            self.row = limit + 1
+        for line in permanent:
+            if self.row <= limit:
+                buf += f"{CSI}{self.row};1H{line}{CSI}K"
+                self.row += 1
+            else:
+                buf += self._set_margin(limit)
+                buf += f"{CSI}{limit};1H\n\r{line}{CSI}K"
+        self.top = min(self.row, limit + 1)
+        if not self.resizing:
+            for i, line in enumerate(region):
+                # clip_ansi: an overwide line would wrap into the next row.
+                buf += f"{CSI}{self.top + i};1H{clip_ansi(line, cols)}{RESET}{CSI}K"
+            buf += f"{CSI}J"  # stale rows under a moved or shrunk region
+        buf += f"{CSI}{self.top};1H"
+        self._emit(buf)
+
+    def _set_margin(self, limit: int) -> str:
+        if self.margin == limit:
+            return ""
+        self.margin = limit
+        return f"{CSI}r{CSI}1;{limit}r"
+
+    def close(self) -> None:
+        """Release the margin and clear the region."""
+        self._emit(f"{CSI}r{CSI}{self.top};1H{CSI}J")
+        self.margin = 0
 
     def permanent(self, *lines: str) -> None:
-        if self.suspended:
-            # Another program (pager) owns the terminal: queue for later.
+        if self.suspended:  # a pager owns the terminal: queue for later
             self._pending.extend(lines)
             return
-        # Erase ephemeral, print permanent lines, repaint ephemeral: one write.
-        buf = f"{CSI}{self.ephemeral_lines}F{CSI}J" if self.ephemeral_lines else ""
-        self.ephemeral_lines = 0
-        buf += "".join(f"{line}\n" for line in lines)
-        buf += self._compose_ephemeral(self.last_ephemeral)
-        self._emit(buf)
+        self.frame(list(lines), self.last_region)
 
     def ephemeral(self, lines: list[str]) -> None:
         if self.suspended:
             return
-        self._emit(self._compose_ephemeral(lines))
+        self.last_region = list(lines)
+        self.frame([], lines)
 
     def suspend(self) -> None:
         """Clear our region and stop touching the terminal."""
-        self.ephemeral([])
-        self.last_ephemeral = []
+        self.close()
+        self.last_region = []
         self.suspended = True
 
     def resume(self) -> int:
@@ -135,8 +211,10 @@ class Display:
         user what they missed.
         """
         self.suspended = False
-        # The pager left the cursor anywhere; start fresh on a new line.
-        self.ephemeral_lines = 0
+        # Pager left the screen in an unknown state: rebuild from history
+        # on the next frame, exactly like after a resize settles.
+        self.cols, self.rows = self.size()
+        self.resizing = True
         pending, self._pending = self._pending, []
         if pending:
             self.permanent(*pending)
@@ -235,6 +313,9 @@ class TTYRenderer:
         self.cooked_termios = termios.tcgetattr(fd)
         tty.setcbreak(fd)
         loop.add_reader(fd, self.on_stdin_readable)
+        # Start the region below the shell prompt instead of at row 1.
+        rows = shutil.get_terminal_size().lines
+        self.display.row = self.display.top = cursor_row(self.display.out, rows)
         # Hide the cursor: it strobes across the region during redraws.
         self._write_ctl(HIDE_CURSOR)
         loop.add_signal_handler(signal.SIGWINCH, self._on_winch)
@@ -286,6 +367,7 @@ class TTYRenderer:
         self.display.ephemeral([])
         # Live region is gone; leave a permanent recap in scrollback.
         self.display.permanent(self.render_summary())
+        self.display.close()
         self._write_ctl(SHOW_CURSOR)
 
     def _write_ctl(self, seq: str) -> None:
@@ -293,10 +375,10 @@ class TTYRenderer:
         self.display.out.flush()
 
     def _on_winch(self) -> None:
-        # Terminal resized: old region may have rewrapped, making the
-        # cursor-up anchor wrong. Abandon it (stale lines become inert
-        # scrollback) and let the next tick draw a fresh region.
-        self.display.ephemeral_lines = 0
+        # Repaint immediately instead of waiting for the next tick; the
+        # display's per-frame size polling does the rest.
+        if not self.pager_active:
+            self.display.frame([], self.display.last_region)
 
     async def _render_loop(self) -> None:
         while True:

--- a/tests/test_tty_renderer.py
+++ b/tests/test_tty_renderer.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 
+import pyte
 import pytest
 
 from nix_fast_build import tty_renderer
@@ -44,47 +45,201 @@ def plain(lines: list[str]) -> str:
     return ANSI.sub("", "\n".join(lines))
 
 
-# ── Display ──────────────────────────────────────────────────────────
+# ── Display (against a pyte terminal emulator) ───────────────────────
+
+WIDTH, HEIGHT = 60, 12
 
 
-def test_display_ephemeral_overwrites_in_place() -> None:
+def emulate(chunks: str) -> pyte.HistoryScreen:
+    screen = pyte.HistoryScreen(WIDTH, HEIGHT, history=1000)
+    pyte.Stream(screen).feed(chunks)
+    return screen
+
+
+def buffer_lines(screen: pyte.HistoryScreen) -> list[str]:
+    """Scrollback plus visible rows, as plain text."""
+    history = [
+        "".join(line[x].data for x in range(WIDTH)).rstrip()
+        for line in screen.history.top
+    ]
+    return history + [row.rstrip() for row in screen.display]
+
+
+def make_display(out: io.StringIO) -> Display:
+    return Display(out, size=lambda: os.terminal_size((WIDTH, HEIGHT)))
+
+
+def test_verdicts_scroll_and_region_stays_at_bottom() -> None:
+    """Verdicts land in scrollback exactly once and in order, while the
+    live region only ever exists as the last rows of the screen."""
     out = io.StringIO()
-    d = Display(out)
-    d.ephemeral(["a", "b"])
-    d.ephemeral(["c"])
-    text = out.getvalue()
-    # Second paint moves up 2 lines, then clears the leftover line.
-    assert f"{CSI}2F" in text
-    assert f"{CSI}J" in text
-    assert d.ephemeral_lines == 1
+    display = make_display(out)
+    verdicts = []
+    for i in range(40):
+        batch = [f"verdict-{i}-a", f"verdict-{i}-b"]
+        verdicts += batch
+        display.frame(batch, ["HEADER", f"running-{i}", f"gist-{i}"])
+    display.close()
+
+    lines = buffer_lines(emulate(out.getvalue()))
+    kept = [line for line in lines if line.startswith("verdict-")]
+    assert kept == verdicts
+    assert sum("HEADER" in line for line in lines) == 0  # cleared on close
+
+
+def test_region_visible_while_running() -> None:
+    out = io.StringIO()
+    display = make_display(out)
+    for i in range(20):
+        display.frame([f"verdict-{i}"], ["HEADER", f"running-{i}"])
+
+    screen = emulate(out.getvalue())
+    lines = buffer_lines(screen)
+    # The region exists exactly once, at the bottom of the visible screen.
+    assert sum("HEADER" in line for line in lines) == 1
+    visible = [row.rstrip() for row in screen.display]
+    assert "HEADER" in visible[-2]
+    assert visible[-1] == "running-19"
+    # No verdict was lost or duplicated by the region redraws.
+    kept = [line for line in lines if line.startswith("verdict-")]
+    assert kept == [f"verdict-{i}" for i in range(20)]
+
+
+def test_region_growth_does_not_eat_verdicts() -> None:
+    """Reserving more bottom rows must not overwrite existing verdicts."""
+    out = io.StringIO()
+    display = make_display(out)
+    display.frame(["verdict-0"], ["HEADER"])
+    display.frame(["verdict-1"], ["HEADER", "run-a", "run-b", "run-c"])
+    display.frame([], ["HEADER"])
+    display.close()
+
+    lines = buffer_lines(emulate(out.getvalue()))
+    kept = [line for line in lines if line.startswith("verdict-")]
+    assert kept == ["verdict-0", "verdict-1"]
+    assert sum("run-a" in line for line in lines) == 0
+
+
+def test_region_starts_at_the_prompt_row_without_a_gap() -> None:
+    """Output continues right below the shell prompt instead of jumping
+    to the bottom of the screen."""
+    out = io.StringIO()
+    display = Display(out, size=lambda: os.terminal_size((WIDTH, HEIGHT)), origin=4)
+    display.frame(["verdict-0", "verdict-1"], ["HEADER", "running"])
+
+    visible = [row.rstrip() for row in emulate(out.getvalue()).display]
+    assert visible[3:7] == ["verdict-0", "verdict-1", "HEADER", "running"]
+    assert all(not row for row in visible[7:])
+
+
+def test_resize_keeps_single_region() -> None:
+    """A SIGWINCH shows up as a changed size() result on the next frame.
+    The renderer must re-anchor the region without duplicating it."""
+    size = {"cols": WIDTH, "rows": HEIGHT}
+    out = io.StringIO()
+    display = Display(out, size=lambda: os.terminal_size((size["cols"], size["rows"])))
+    screen = pyte.HistoryScreen(WIDTH, HEIGHT, history=1000)
+    stream = pyte.Stream(screen)
+
+    def frame(batch: list[str], region: list[str]) -> None:
+        mark = out.tell()
+        display.frame(batch, region)
+        stream.feed(out.getvalue()[mark:])
+
+    for i in range(10):
+        frame([f"verdict-{i}"], ["HEADER", f"running-{i}"])
+    # The terminal shrinks between two frames.
+    size.update(cols=40, rows=8)
+    screen.resize(8, 40)
+    for i in range(10, 16):
+        frame([f"verdict-{i}"], ["HEADER", f"running-{i}"])
+
+    lines = buffer_lines(screen)
+    assert sum("HEADER" in line for line in lines) == 1
+    visible = [row.rstrip() for row in screen.display]
+    assert "HEADER" in visible[-2]
+    assert visible[-1] == "running-15"
+    # Verdicts printed after the resize are neither lost nor duplicated.
+    post = [
+        line for line in lines if line.startswith("verdict-1") and line != "verdict-1"
+    ]
+    assert post == [f"verdict-{i}" for i in range(10, 16)]
+
+
+def test_resize_burst_never_erases_verdicts() -> None:
+    """While the terminal is being resized (a burst of size changes, one
+    per frame) nothing may be erased and the region stays hidden until
+    the size settles again."""
+    size = {"cols": WIDTH, "rows": HEIGHT}
+    out = io.StringIO()
+    display = Display(out, size=lambda: os.terminal_size((size["cols"], size["rows"])))
+    screen = pyte.HistoryScreen(WIDTH, HEIGHT, history=1000)
+    stream = pyte.Stream(screen)
+
+    def frame(batch: list[str], region: list[str]) -> None:
+        mark = out.tell()
+        display.frame(batch, region)
+        stream.feed(out.getvalue()[mark:])
+
+    frame(["verdict-0", "verdict-1"], ["HEADER", "running"])
+    resize_output_start = out.tell()
+    for i, rows in enumerate((11, 10, 9)):  # drag in progress
+        size.update(rows=rows)
+        screen.resize(rows, WIDTH)
+        frame([f"verdict-{2 + i}"], ["HEADER", "running"])
+    burst = out.getvalue()[resize_output_start:]
+    assert "HEADER" not in burst  # region not redrawn mid-resize
+    assert "\x1b[J" not in burst  # nothing erased
+    assert "\x1b[2J" not in burst
+
+    # Once the size settles the visible screen is rebuilt from the model:
+    # most recent verdicts on top, region below, no stale copies.
+    frame(["verdict-5"], ["HEADER", "running"])
+    frame(["verdict-6"], ["HEADER", "running"])
+    visible = [row.rstrip() for row in screen.display]
+    shown = [line for line in visible if line.startswith("verdict-")]
+    assert shown == [f"verdict-{i}" for i in range(7)]
+    assert visible.index("HEADER") == len(shown)
+    assert sum("HEADER" in line for line in visible) == 1
+
+
+def test_long_verdicts_wrap_without_corrupting_region() -> None:
+    out = io.StringIO()
+    display = make_display(out)
+    long_line = "verdict-long " + "x" * (2 * WIDTH)
+    for _ in range(5):
+        display.frame([long_line], ["HEADER", "running"])
+
+    lines = buffer_lines(emulate(out.getvalue()))
+    assert sum("HEADER" in line for line in lines) == 1
+    assert sum(line.startswith("verdict-long") for line in lines) == 5
 
 
 def test_display_permanent_above_ephemeral() -> None:
     out = io.StringIO()
-    d = Display(out)
+    d = make_display(out)
     d.ephemeral(["status"])
     d.permanent("event")
-    text = out.getvalue()
-    # Permanent line printed, ephemeral repainted afterwards.
-    assert text.index("event") < text.rindex("status")
-    assert d.ephemeral_lines == 1
+    visible = [row.rstrip() for row in emulate(out.getvalue()).display]
+    assert visible.index("event") < visible.index("status")
 
 
 def test_display_suspend_queues_permanent() -> None:
     out = io.StringIO()
-    d = Display(out)
+    d = make_display(out)
     d.ephemeral(["status"])
     d.suspend()
     before = out.getvalue()
     d.permanent("while paging")
     assert out.getvalue() == before  # nothing written while suspended
     assert d.resume() == 1
-    assert "while paging" in out.getvalue()
+    visible = [row.rstrip() for row in emulate(out.getvalue()).display]
+    assert "while paging" in visible
 
 
 def test_display_sync_markers() -> None:
     out = io.StringIO()
-    d = Display(out)
+    d = make_display(out)
     d.ephemeral(["x"])
     assert out.getvalue().startswith(f"{CSI}?2026h")
     assert out.getvalue().endswith(f"{CSI}?2026l")
@@ -291,16 +446,18 @@ def test_unknown_key_flashes() -> None:
 
 def test_display_log_handler() -> None:
     out = io.StringIO()
-    d = Display(out)
+    d = make_display(out)
     d.ephemeral(["status"])
     h = DisplayLogHandler(d)
     logger = logging.getLogger("nfb-test")
     logger.addHandler(h)
     logger.warning("multi\nline")
     logger.removeHandler(h)
-    text = out.getvalue()
-    assert "WARNING:nfb-test:multi" in text
-    assert d.ephemeral_lines == 1  # region repainted after the log lines
+    visible = [row.rstrip() for row in emulate(out.getvalue()).display]
+    assert "WARNING:nfb-test:multi" in visible
+    assert "line" in visible
+    # Region repainted below the log lines.
+    assert visible.index("status") > visible.index("line")
 
 
 def test_browser_succeeded_label() -> None:


### PR DESCRIPTION

The cursor-up anchor broke when a resize rewrapped the scrollback,
leaving stale rows. Port nbo's Display: absolute rows with a scroll
margin, erase nothing while the size changes, rebuild from history once
it settles. Tests now assert on pyte-emulated screen content.
