### PR TITLE
stream built intermediates to all caches via batched upload queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ usage: nix-fast-build [-h] [--nix NIX] [--nix-eval-jobs NIX_EVAL_JOBS]
                       [--cachix-cache CACHIX_CACHE]
                       [--attic-cache ATTIC_CACHE]
                       [--attic-ignore-upstream-cache-filter]
-                      [--attic-push-build-closure]
+                      [--push-build-closure] [--attic-push-build-closure]
                       [--niks3-server NIKS3_SERVER] [--no-nom] [--no-fold]
                       [--stall-timeout STALL_TIMEOUT] [--systems SYSTEMS]
                       [--retries RETRIES] [--no-link] [--out-link OUT_LINK]
@@ -388,11 +388,15 @@ options:
                         Pass --ignore-upstream-cache-filter to attic push,
                         uploading all paths even if attic thinks they exist in
                         an upstream cache (default: false)
-  --attic-push-build-closure
-                        Also push the build-time closure to attic, not just
-                        the runtime closure. Useful for caching intermediate
+  --push-build-closure  Also push outputs of every intermediate derivation
+                        that was built (not substituted) while building an
+                        attribute to the configured caches (--copy-
+                        to/--cachix-cache/--attic-cache/--niks3-server), as
+                        soon as they finish. Useful for caching intermediate
                         build products in ephemeral CI environments (default:
                         false)
+  --attic-push-build-closure
+                        Deprecated alias for --push-build-closure
   --niks3-server NIKS3_SERVER
                         Niks3 server URL to upload to (auth from
                         ~/.config/niks3/auth-token or NIKS3_AUTH_TOKEN_FILE)
@@ -413,8 +417,8 @@ options:
                         prefix (e.g. 'result'). By default builds are only gc-
                         rooted for the duration of the run.
   --store STORE         Nix store URL to build against (e.g. ssh-ng://host).
-                        Evaluation stays local; only builds are dispatched.
-                        Conflicts with --out-link.
+                        Evaluation stays local and only builds are dispatched.
+                        Implies --builders ''. Conflicts with --out-link.
   --remote REMOTE       Remote machine to build on
   --always-upload-source
                         Always upload sources to remote machine. This is

--- a/nix_fast_build/__init__.py
+++ b/nix_fast_build/__init__.py
@@ -5,12 +5,11 @@ import os
 import sys
 from asyncio import Queue, TaskGroup
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from .build import Build, BuildQueue, JobQueue, OptionalQueue, StopTask
+from .build import BuildQueue, JobQueue, OptionalQueue, StopTask
 from .ci_renderer import CIRenderer
 from .errors import Error
 from .options import EvalMode, Options, ResultFormat, parse_args
@@ -30,11 +29,19 @@ from .results import Result, ResultType, Summary
 from .sources import upload_sources
 from .term import fold_markers, is_ignored_eval_line, sanitize_line, want_color
 from .tty_renderer import TTYRenderer
+from .upload import (
+    AtticUploader,
+    CachixUploader,
+    Niks3Uploader,
+    NixCopyUploader,
+    Uploader,
+    UploadQueue,
+    run_upload_worker,
+)
 from .workers import (
     report_progress,
     run_builds,
     run_evaluation,
-    run_niks3_upload,
     run_queue_worker,
 )
 
@@ -120,55 +127,54 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
     result_queue: Queue[Result | None] = Queue()
     build_queue = JobQueue()
 
-    # Build list of optional queues that are actually needed
+    # Post-build queues that are actually configured.
     optional_queues: list[OptionalQueue] = []
+    upload_queues: list[UploadQueue] = []
+    build_queues: list[BuildQueue] = []
 
-    def add_queue(
-        name: str,
-        result_type: ResultType,
-        push: Callable[[Build], Awaitable[int]],
-    ) -> BuildQueue:
-        queue = BuildQueue()
+    def add_uploader(uploader: Uploader) -> None:
+        # single worker: it batches whatever is queued into one push
+        queue = UploadQueue()
+        upload_queues.append(queue)
         optional_queues.append(
             OptionalQueue(
                 queue,
-                opts.max_jobs,
-                name,
-                lambda: run_queue_worker(queue, result_queue, result_type, name, push),
-            )
-        )
-        return queue
-
-    upload_queue: BuildQueue | None = None
-    if opts.copy_to:
-        upload_queue = add_queue(
-            "upload", ResultType.UPLOAD, lambda b: b.upload(stack, opts)
-        )
-
-    if cachix_socket_path is not None:
-        # Local alias so mypy sees a non-None capture in the lambda.
-        socket_path = cachix_socket_path
-        add_queue(
-            "cachix", ResultType.CACHIX, lambda b: b.upload_cachix(socket_path, opts)
-        )
-
-    if opts.attic_cache:
-        add_queue("attic", ResultType.ATTIC, lambda b: b.upload_attic(opts))
-
-    if opts.niks3_server:
-        # Single niks3 worker since it batches uploads internally
-        niks3_queue = BuildQueue()
-        optional_queues.append(
-            OptionalQueue(
-                niks3_queue,
                 1,
-                "niks3",
-                lambda: run_niks3_upload(niks3_queue, result_queue, opts),
+                uploader.name,
+                lambda: run_upload_worker(queue, result_queue, uploader),
             )
         )
+
+    if opts.copy_to:
+        add_uploader(NixCopyUploader("upload", ResultType.UPLOAD, opts))
+    if cachix_socket_path is not None:
+        add_uploader(
+            CachixUploader(
+                "cachix", ResultType.CACHIX, opts, socket_path=cachix_socket_path
+            )
+        )
+    if opts.attic_cache:
+        add_uploader(AtticUploader("attic", ResultType.ATTIC, opts))
+    if opts.niks3_server:
+        add_uploader(Niks3Uploader("niks3", ResultType.NIKS3, opts))
 
     if opts.remote_url and opts.download:
-        add_queue("download", ResultType.DOWNLOAD, lambda b: b.download(stack, opts))
+        download_queue = BuildQueue()
+        build_queues.append(download_queue)
+        optional_queues.append(
+            OptionalQueue(
+                download_queue,
+                opts.max_jobs,
+                "download",
+                lambda: run_queue_worker(
+                    download_queue,
+                    result_queue,
+                    ResultType.DOWNLOAD,
+                    "download",
+                    lambda b: b.download(stack, opts),
+                ),
+            )
+        )
 
     async def dequeue_results() -> None:
         # Stream results as they arrive and collect them for the final
@@ -188,7 +194,7 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
         # Ends on its own at eval stderr EOF (process exit).
         tasks.append(tg.create_task(forward_eval_stderr(), name="eval-stderr"))
         evaluation = tg.create_task(
-            run_evaluation(eval_proc, build_queue, upload_queue, result_queue, opts)
+            run_evaluation(eval_proc, build_queue, upload_queues, result_queue, opts)
         )
         tasks.append(evaluation)
         logger.debug("Starting %d build tasks", opts.max_jobs)
@@ -197,7 +203,8 @@ async def run(stack: AsyncExitStack, opts: Options) -> int:
                 run_builds(
                     stack,
                     build_queue,
-                    [oq.queue for oq in optional_queues],
+                    upload_queues,
+                    build_queues,
                     result_queue,
                     opts=opts,
                     renderer=renderer,

--- a/nix_fast_build/build.py
+++ b/nix_fast_build/build.py
@@ -9,11 +9,10 @@ from asyncio.subprocess import Process
 from collections.abc import AsyncIterator, Callable, Coroutine
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, TypeVar
 
-from .log_format import LogParser
-from .options import Options, maybe_remote, nix_shell
+from .log_format import ActivityStopped, ActivityType, LogParser
+from .options import Options, maybe_remote
 from .processes import ensure_stop
 from .renderer import BuildOutput, Renderer
 
@@ -39,8 +38,9 @@ class Build:
         stack: AsyncExitStack,
         opts: Options,
         renderer: Renderer | None = None,
+        on_built: Callable[[str], None] | None = None,
     ) -> BuildResult:
-        """Build and return BuildResult."""
+        """on_built receives each intermediate .drv nix ran a builder for."""
         rc = 0
         sink: BuildOutput | None = None
         for attempt in range(opts.retries + 1):
@@ -48,7 +48,13 @@ class Build:
                 sink = renderer.start_build(self.attr, self.drv_path)
             try:
                 proc = await stack.enter_async_context(
-                    nix_build(self.attr, self.drv_path, opts, sink=sink)
+                    nix_build(
+                        self.attr,
+                        self.drv_path,
+                        opts,
+                        sink=sink,
+                        on_built=on_built,
+                    )
                 )
                 rc = await proc.wait()
             except BaseException:
@@ -96,111 +102,6 @@ class Build:
             logger.debug(f"Failed to get build log: {e}")
         return ""
 
-    async def upload(self, exit_stack: AsyncExitStack, opts: Options) -> int:
-        if not opts.copy_to or not self.outputs:
-            return 0
-        cmd = opts.nix_command(
-            [
-                "copy",
-                "--log-format",
-                "raw",
-                "--to",
-                opts.copy_to,
-                *list(self.outputs.values()),
-            ]
-        )
-        cmd = maybe_remote(cmd, opts)
-        logger.debug("run %s", shlex.join(cmd))
-        proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
-        await exit_stack.enter_async_context(ensure_stop(proc, cmd))
-        return await proc.wait()
-
-    async def upload_cachix(self, cachix_socket_path: Path, opts: Options) -> int:
-        if not self.outputs:
-            return 0
-        cmd = maybe_remote(
-            [
-                *nix_shell("nixpkgs#cachix", "cachix"),
-                "daemon",
-                "push",
-                "--socket",
-                str(cachix_socket_path),
-                *list(self.outputs.values()),
-            ],
-            opts,
-        )
-        logger.debug("run %s", shlex.join(cmd))
-        proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
-        return await proc.wait()
-
-    async def _query_build_closure(self, opts: Options) -> list[str]:
-        """Query all realised store paths in the build closure of this derivation.
-
-        Returns output paths of all build-time requisites that exist in
-        the store.  After a successful build these are guaranteed to be
-        present because nix had to build or substitute every dependency.
-        """
-        query_cmd = maybe_remote(
-            [
-                "nix-store",
-                "--query",
-                "--requisites",
-                "--include-outputs",
-                self.drv_path,
-            ],
-            opts,
-        )
-        proc = await asyncio.create_subprocess_exec(
-            *query_cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
-        if proc.returncode != 0:
-            logger.warning(
-                "nix-store -qR --include-outputs failed for %s (rc=%d), "
-                "falling back to output paths only",
-                self.drv_path,
-                proc.returncode,
-            )
-            return list(self.outputs.values())
-
-        paths: list[str] = []
-        for line in stdout.decode().splitlines():
-            path = line.strip()
-            if path and not path.endswith(".drv"):
-                paths.append(path)
-        return paths or list(self.outputs.values())
-
-    async def upload_attic(self, opts: Options) -> int:
-        if opts.attic_cache is None or not self.outputs:
-            return 0
-        push_args = ["push"]
-        if opts.attic_ignore_upstream_cache_filter:
-            push_args.append("--ignore-upstream-cache-filter")
-        push_args.append(opts.attic_cache)
-        if opts.attic_push_build_closure:
-            paths = await self._query_build_closure(opts)
-            push_args.append("--no-closure")
-            push_args.extend(paths)
-            logger.debug(
-                "attic push: %d paths (build closure) for %s",
-                len(paths),
-                self.attr,
-            )
-        else:
-            push_args.extend(self.outputs.values())
-        cmd = maybe_remote(
-            [
-                *nix_shell("nixpkgs#attic-client", "attic"),
-                *push_args,
-            ],
-            opts,
-        )
-        logger.debug("run %s", shlex.join(cmd))
-        proc = await asyncio.create_subprocess_exec(*cmd, stdout=sys.stderr.fileno())
-        return await proc.wait()
-
     def out_link_args(self, opts: Options) -> list[str]:
         if opts.out_link is not None:
             return ["--out-link", opts.out_link + "-" + self.attr]
@@ -243,7 +144,7 @@ T = TypeVar("T")
 class OptionalQueue:
     """Post-build queue with the workers that drain it, for proper shutdown."""
 
-    queue: "BuildQueue"
+    queue: "QueueWithContext[Any]"
     worker_count: int
     name: str
     make_worker: Callable[[], Coroutine[Any, Any, int]]
@@ -271,6 +172,7 @@ async def nix_build(
     installable: str,
     opts: Options,
     sink: BuildOutput | None = None,
+    on_built: Callable[[str], None] | None = None,
 ) -> AsyncIterator[Process]:
     args = opts.nix_command(
         ["build", f"{installable}^*", "--keep-going", *opts.options, *opts.store_args]
@@ -303,10 +205,20 @@ async def nix_build(
         parser = LogParser()
         try:
             async for line in proc.stderr:
+                event = parser.parse_line(line)
+                if event is None:
+                    continue
+                if (
+                    on_built is not None
+                    and isinstance(event, ActivityStopped)
+                    and event.activity is not None
+                    and event.activity.type == ActivityType.BUILD
+                    and event.activity.fields
+                    and str(event.activity.fields[0]) != installable
+                ):
+                    on_built(str(event.activity.fields[0]))
                 if sink is not None:
-                    event = parser.parse_line(line)
-                    if event is not None:
-                        sink.on_event(event)
+                    sink.on_event(event)
         except ValueError:
             # Line exceeded the stream limit. Stop forwarding but don't
             # let the exception escape the cleanup that awaits this task.

--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -74,7 +74,7 @@ class Options:
 
     attic_cache: str | None = None
     attic_ignore_upstream_cache_filter: bool = False
-    attic_push_build_closure: bool = False
+    push_build_closure: bool = False
 
     niks3_server: str | None = None
 
@@ -281,8 +281,13 @@ async def parse_args(args: list[str]) -> Options:
         action="store_true",
     )
     parser.add_argument(
+        "--push-build-closure",
+        help="Also push outputs of every intermediate derivation that was built (not substituted) while building an attribute to the configured caches (--copy-to/--cachix-cache/--attic-cache/--niks3-server), as soon as they finish. Useful for caching intermediate build products in ephemeral CI environments (default: false)",
+        action="store_true",
+    )
+    parser.add_argument(
         "--attic-push-build-closure",
-        help="Also push the build-time closure to attic, not just the runtime closure. Useful for caching intermediate build products in ephemeral CI environments (default: false)",
+        help="Deprecated alias for --push-build-closure",
         action="store_true",
     )
     parser.add_argument(
@@ -452,6 +457,12 @@ async def parse_args(args: list[str]) -> Options:
         if any(name in ("store", "eval-store", "builders") for name, _ in a.option):
             parser.error("--option store/eval-store/builders conflicts with --store")
 
+    if a.attic_push_build_closure:
+        logger.warning(
+            "--attic-push-build-closure is deprecated, use --push-build-closure"
+        )
+        a.push_build_closure = True
+
     if a.no_link:
         logger.warning(
             "--no-link is deprecated and has no effect: "
@@ -563,7 +574,7 @@ async def parse_args(args: list[str]) -> Options:
         cachix_cache=a.cachix_cache,
         attic_cache=a.attic_cache,
         attic_ignore_upstream_cache_filter=a.attic_ignore_upstream_cache_filter,
-        attic_push_build_closure=a.attic_push_build_closure,
+        push_build_closure=a.push_build_closure,
         niks3_server=a.niks3_server,
         store=a.store,
         out_link=a.out_link,

--- a/nix_fast_build/upload.py
+++ b/nix_fast_build/upload.py
@@ -1,0 +1,209 @@
+import asyncio
+import logging
+import os
+import shlex
+import sys
+import timeit
+from asyncio import Queue
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .build import QueueWithContext, StopTask
+from .options import Options, maybe_remote, nix_shell
+from .processes import ensure_stop
+from .results import Result, ResultType
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UploadItem:
+    attr: str
+    # output paths or .drv paths (resolved to outputs by the worker)
+    paths: list[str]
+
+
+UploadQueue = QueueWithContext[UploadItem | StopTask]
+
+
+async def _run_with_stdin(
+    cmd: list[str],
+    lines: Sequence[str],
+    *,
+    env: dict[str, str] | None = None,
+    capture: bool = False,
+) -> tuple[int, str]:
+    logger.debug("run %s (%d paths on stdin)", shlex.join(cmd), len(lines))
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        env=env,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE if capture else sys.stderr.fileno(),
+    )
+    async with ensure_stop(proc, cmd):
+        stdout, _ = await proc.communicate(("\n".join(lines) + "\n").encode())
+    assert proc.returncode is not None
+    return proc.returncode, (stdout or b"").decode()
+
+
+@dataclass
+class Uploader:
+    name: str
+    result_type: ResultType
+    opts: Options
+    pushed: set[str] = field(default_factory=set)
+
+    def command(self) -> tuple[list[str], dict[str, str] | None]:
+        """Command reading newline-separated store paths on stdin (ARG_MAX)."""
+        raise NotImplementedError
+
+    async def send(self, paths: list[str]) -> int:
+        cmd, env = self.command()
+        rc, _ = await _run_with_stdin(maybe_remote(cmd, self.opts), paths, env=env)
+        return rc
+
+    async def push(self, raw: set[str]) -> int:
+        paths = await resolve_valid_outputs(raw, self.opts)
+        if not paths:
+            return 0
+        return await self.send(sorted(paths))
+
+
+@dataclass
+class NixCopyUploader(Uploader):
+    def command(self) -> tuple[list[str], dict[str, str] | None]:
+        assert self.opts.copy_to is not None
+        return [
+            "xargs",
+            *self.opts.nix_command(
+                ["copy", "--log-format", "raw", "--to", self.opts.copy_to]
+            ),
+        ], None
+
+
+@dataclass
+class CachixUploader(Uploader):
+    socket_path: Path = Path()
+
+    def command(self) -> tuple[list[str], dict[str, str] | None]:
+        return [
+            "xargs",
+            *nix_shell("nixpkgs#cachix", "cachix"),
+            "daemon",
+            "push",
+            "--socket",
+            str(self.socket_path),
+        ], None
+
+
+@dataclass
+class AtticUploader(Uploader):
+    def command(self) -> tuple[list[str], dict[str, str] | None]:
+        assert self.opts.attic_cache is not None
+        args = [*nix_shell("nixpkgs#attic-client", "attic"), "push", "--stdin"]
+        if self.opts.attic_ignore_upstream_cache_filter:
+            args.append("--ignore-upstream-cache-filter")
+        args.append(self.opts.attic_cache)
+        return args, None
+
+
+@dataclass
+class Niks3Uploader(Uploader):
+    def command(self) -> tuple[list[str], dict[str, str] | None]:
+        assert self.opts.niks3_server is not None
+        env = os.environ.copy()
+        env["NIKS3_SERVER_URL"] = self.opts.niks3_server
+        return ["xargs", *nix_shell("github:Mic92/niks3", "niks3"), "push"], env
+
+
+async def resolve_valid_outputs(paths: set[str], opts: Options) -> set[str]:
+    """Resolve .drv paths to outputs and drop invalid ones (failed builds)."""
+    drvs = sorted(p for p in paths if p.endswith(".drv"))
+    outs = {p for p in paths if not p.endswith(".drv")}
+    if drvs:
+        rc, stdout = await _run_with_stdin(
+            maybe_remote(["xargs", "nix-store", "--query", "--outputs"], opts),
+            drvs,
+            capture=True,
+        )
+        if rc != 0:
+            logger.warning("nix-store --query --outputs failed (rc=%d)", rc)
+        outs.update(stdout.split())
+    if not outs:
+        return outs
+    rc, stdout = await _run_with_stdin(
+        maybe_remote(
+            ["xargs", "nix-store", "--check-validity", "--print-invalid"], opts
+        ),
+        sorted(outs),
+        capture=True,
+    )
+    if rc != 0:
+        logger.warning("nix-store --check-validity failed (rc=%d)", rc)
+        return outs
+    return outs - set(stdout.split())
+
+
+def _drain(queue: UploadQueue, first: UploadItem) -> list[UploadItem]:
+    items = [first]
+    while True:
+        try:
+            item = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return items
+        queue.task_done()
+        if isinstance(item, StopTask):
+            queue.put_nowait(item)
+            return items
+        items.append(item)
+
+
+async def run_upload_worker(
+    queue: UploadQueue,
+    result_queue: "Queue[Result | None]",
+    uploader: Uploader,
+) -> int:
+    while True:
+        async with queue.get_context() as first:
+            if isinstance(first, StopTask):
+                logger.debug("finish %s task", uploader.name)
+                return 0
+            items = _drain(queue, first)
+
+            by_attr: dict[str, set[str]] = {}
+            for item in items:
+                new = set(item.paths) - uploader.pushed
+                if new:
+                    by_attr.setdefault(item.attr, set()).update(new)
+            if not by_attr:
+                continue
+
+            start = timeit.default_timer()
+            batch = set().union(*by_attr.values())
+            rc = await uploader.push(batch)
+            rcs = dict.fromkeys(by_attr, rc)
+            if rc != 0 and len(by_attr) > 1:
+                logger.warning(
+                    "%s: batch of %d paths failed (rc=%d), retrying per attribute",
+                    uploader.name,
+                    len(batch),
+                    rc,
+                )
+                for attr, paths in by_attr.items():
+                    rcs[attr] = await uploader.push(paths)
+            duration = (timeit.default_timer() - start) / len(by_attr)
+            for attr, attr_rc in rcs.items():
+                if attr_rc == 0:
+                    uploader.pushed.update(by_attr[attr])
+                await result_queue.put(
+                    Result(
+                        result_type=uploader.result_type,
+                        attr=attr,
+                        success=attr_rc == 0,
+                        duration=duration,
+                        error=f"{uploader.name} exited with {attr_rc}"
+                        if attr_rc != 0
+                        else None,
+                    )
+                )

--- a/nix_fast_build/workers.py
+++ b/nix_fast_build/workers.py
@@ -1,9 +1,6 @@
 import asyncio
 import json
 import logging
-import os
-import shlex
-import sys
 import timeit
 from asyncio import Queue
 from asyncio.subprocess import Process
@@ -13,9 +10,10 @@ from typing import Any
 
 from .build import Build, BuildQueue, Job, JobQueue, OptionalQueue, StopTask
 from .errors import Error
-from .options import Options, maybe_remote, nix_shell
+from .options import Options
 from .renderer import Renderer
 from .results import Result, ResultType
+from .upload import UploadItem, UploadQueue
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +25,7 @@ def _job_outputs(job: dict[str, Any]) -> dict[str, str]:
 async def run_evaluation(
     eval_proc: Process,
     build_queue: JobQueue,
-    upload_queue: BuildQueue | None,
+    upload_queues: list[UploadQueue],
     result_queue: "Queue[Result | None]",
     opts: Options,
 ) -> int:
@@ -70,8 +68,8 @@ async def run_evaluation(
         if cache_status == "cached":
             continue
         if cache_status == "local":
-            if upload_queue is not None:
-                upload_queue.put_nowait(Build(attr, job["drvPath"], outputs))
+            for uq in upload_queues:
+                uq.put_nowait(UploadItem(attr, list(outputs.values())))
             # already valid locally: build only if a result symlink is wanted
             if opts.out_link is None:
                 continue
@@ -89,7 +87,8 @@ async def run_evaluation(
 async def run_builds(
     stack: AsyncExitStack,
     build_queue: JobQueue,
-    optional_queues: list[BuildQueue],
+    upload_queues: list[UploadQueue],
+    build_queues: list[BuildQueue],
     result_queue: "Queue[Result | None]",
     *,
     opts: Options,
@@ -110,8 +109,17 @@ async def run_builds(
                 continue
             drv_paths.add(job.drv_path)
             build = Build(job.attr, job.drv_path, job.outputs)
+            on_built = None
+            if opts.push_build_closure and upload_queues:
+
+                def on_built(drv: str, attr: str = job.attr) -> None:
+                    for uq in upload_queues:
+                        uq.put_nowait(UploadItem(attr, [drv]))
+
             start_time = timeit.default_timer()
-            build_result = await build.build(stack, opts, renderer=renderer)
+            build_result = await build.build(
+                stack, opts, renderer=renderer, on_built=on_built
+            )
             await result_queue.put(
                 Result(
                     result_type=ResultType.BUILD,
@@ -130,8 +138,11 @@ async def run_builds(
             if build_result.return_code != 0:
                 opts.signal_stop()
                 continue
-            for queue in optional_queues:
-                queue.put_nowait(build)
+            if job.outputs:
+                for uq in upload_queues:
+                    uq.put_nowait(UploadItem(job.attr, list(job.outputs.values())))
+            for bq in build_queues:
+                bq.put_nowait(build)
 
 
 async def run_queue_worker(
@@ -158,70 +169,6 @@ async def run_queue_worker(
                     error=f"{label} exited with {rc}" if rc != 0 else None,
                 )
             )
-
-
-async def run_niks3_upload(
-    niks3_queue: BuildQueue,
-    result_queue: "Queue[Result | None]",
-    opts: Options,
-) -> int:
-    while True:
-        # Wait for at least one item
-        async with niks3_queue.get_context() as first_item:
-            if isinstance(first_item, StopTask):
-                logger.debug("finish niks3 upload task")
-                return 0
-
-            # Collect this build plus any others currently queued
-            builds: list[Build] = [first_item]
-            while not niks3_queue.empty():
-                try:
-                    item = niks3_queue.get_nowait()
-                    niks3_queue.task_done()
-                    if isinstance(item, StopTask):
-                        # Put it back for proper shutdown
-                        niks3_queue.put_nowait(item)
-                        break
-                    builds.append(item)
-                except asyncio.QueueEmpty:
-                    break
-
-            # Collect all output paths
-            all_outputs: list[str] = []
-            for build in builds:
-                all_outputs.extend(build.outputs.values())
-
-            start_time = timeit.default_timer()
-            env = os.environ.copy()
-            # niks3_server is guaranteed non-None since this worker is only created when configured
-            assert opts.niks3_server is not None
-            env["NIKS3_SERVER_URL"] = opts.niks3_server
-            cmd = maybe_remote(
-                [
-                    *nix_shell("github:Mic92/niks3", "niks3"),
-                    "push",
-                    *all_outputs,
-                ],
-                opts,
-            )
-            logger.debug("run %s", shlex.join(cmd))
-            proc = await asyncio.create_subprocess_exec(
-                *cmd, env=env, stdout=sys.stderr.fileno()
-            )
-            rc = await proc.wait()
-            duration = timeit.default_timer() - start_time
-
-            # Record result for each build
-            for build in builds:
-                await result_queue.put(
-                    Result(
-                        result_type=ResultType.NIKS3,
-                        attr=build.attr,
-                        success=rc == 0,
-                        duration=duration / len(builds),
-                        error=f"niks3 upload exited with {rc}" if rc != 0 else None,
-                    )
-                )
 
 
 async def report_progress(

--- a/tests/test_built_drvs.py
+++ b/tests/test_built_drvs.py
@@ -1,0 +1,44 @@
+import asyncio
+from contextlib import AsyncExitStack
+from pathlib import Path
+
+from nix_fast_build import Options
+from nix_fast_build.build import Build
+
+# substituted dep (108), built intermediate (105), built toplevel (105)
+LOG = r"""
+@nix {"action":"start","id":1,"level":4,"parent":0,"text":"querying info","type":109,"fields":["/nix/store/aaa-dep","https://cache.nixos.org"]}
+@nix {"action":"stop","id":1}
+@nix {"action":"start","id":2,"level":3,"parent":0,"text":"fetching dep","type":108,"fields":["/nix/store/aaa-dep","https://cache.nixos.org"]}
+@nix {"action":"stop","id":2}
+@nix {"action":"start","id":3,"level":3,"parent":0,"text":"building '/nix/store/bbb-wheel.drv'","type":105,"fields":["/nix/store/bbb-wheel.drv","",1,1]}
+@nix {"action":"result","id":3,"type":101,"fields":["compiling"]}
+@nix {"action":"stop","id":3}
+@nix {"action":"start","id":4,"level":3,"parent":0,"text":"building '/nix/store/ccc-hello.drv'","type":105,"fields":["/nix/store/ccc-hello.drv","",1,1]}
+@nix {"action":"stop","id":4}
+""".strip()
+
+
+def test_reports_built_intermediates(tmp_path: Path) -> None:
+    log = tmp_path / "log"
+    log.write_text(LOG + "\n")
+    fake_nix = tmp_path / "nix"
+    fake_nix.write_text(f"#!/usr/bin/env bash\ncat {log} >&2\n")
+    fake_nix.chmod(0o755)
+    built: list[str] = []
+
+    async def go() -> int:
+        build = Build(
+            "hello", "/nix/store/ccc-hello.drv", {"out": "/nix/store/ccc-hello"}
+        )
+        async with AsyncExitStack() as stack:
+            res = await build.build(
+                stack,
+                Options(nix_bin=[str(fake_nix)], build_gcroot_dir=tmp_path),
+                on_built=built.append,
+            )
+            return res.return_code
+        raise AssertionError
+
+    assert asyncio.run(go()) == 0
+    assert built == ["/nix/store/bbb-wheel.drv"]

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,116 @@
+import asyncio
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from nix_fast_build import Options
+from nix_fast_build.build import StopTask
+from nix_fast_build.results import Result, ResultType
+from nix_fast_build.upload import (
+    Uploader,
+    UploadItem,
+    UploadQueue,
+    run_upload_worker,
+)
+
+# --query --outputs maps X.drv -> X. --print-invalid reports "broken" paths.
+FAKE_NIX_STORE = """#!/usr/bin/env bash
+mode=$*
+for p in "$@"; do
+  [[ $p == /nix/store/* ]] || continue
+  case "$mode" in
+    *--outputs*) echo "${p%.drv}" ;;
+    *--print-invalid*) [[ $p == *broken* ]] && echo "$p" ;;
+  esac
+done
+exit 0
+"""
+
+
+@dataclass
+class RecordingUploader(Uploader):
+    calls: list[list[str]] = field(default_factory=list)
+    fail_if: str = ""
+
+    async def send(self, paths: list[str]) -> int:
+        self.calls.append(paths)
+        return 1 if self.fail_if and self.fail_if in paths else 0
+
+
+@pytest.fixture
+def fake_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "nix-store").write_text(FAKE_NIX_STORE)
+    (tmp_path / "nix-store").chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+
+
+def run_worker(uploader: Uploader, batches: list[list[UploadItem]]) -> list[Result]:
+
+    async def go() -> list[Result]:
+        queue = UploadQueue()
+        results: asyncio.Queue[Result | None] = asyncio.Queue()
+        task = asyncio.create_task(run_upload_worker(queue, results, uploader))
+        for batch in batches:
+            for item in batch:
+                queue.put_nowait(item)
+            await queue.join()
+        queue.put_nowait(StopTask())
+        await task
+        out: list[Result] = []
+        while not results.empty():
+            r = results.get_nowait()
+            assert r is not None
+            out.append(r)
+        return out
+
+    return asyncio.run(go())
+
+
+@pytest.mark.usefixtures("fake_path")
+def test_batches_resolves_drvs_filters_invalid_and_dedups() -> None:
+    up = RecordingUploader("test", ResultType.ATTIC, Options())
+    results = run_worker(
+        up,
+        [
+            [
+                UploadItem("a", ["/nix/store/x-lib.drv"]),
+                UploadItem("b", ["/nix/store/x-lib.drv", "/nix/store/y-broken.drv"]),
+                UploadItem("a", ["/nix/store/a-out"]),
+            ],
+            [UploadItem("b", ["/nix/store/x-lib.drv", "/nix/store/b-out"])],
+        ],
+    )
+    assert up.calls == [
+        ["/nix/store/a-out", "/nix/store/x-lib"],
+        ["/nix/store/b-out"],
+    ]
+    assert [(r.attr, r.success) for r in results] == [
+        ("a", True),
+        ("b", True),
+        ("b", True),
+    ]
+
+
+@pytest.mark.usefixtures("fake_path")
+def test_failed_batch_falls_back_per_attr() -> None:
+    up = RecordingUploader(
+        "test", ResultType.ATTIC, Options(), fail_if="/nix/store/b-bad"
+    )
+    results = run_worker(
+        up,
+        [
+            [
+                UploadItem("a", ["/nix/store/a-out"]),
+                UploadItem("b", ["/nix/store/b-bad"]),
+            ]
+        ],
+    )
+    assert up.calls == [
+        ["/nix/store/a-out", "/nix/store/b-bad"],
+        ["/nix/store/a-out"],
+        ["/nix/store/b-bad"],
+    ]
+    assert {(r.attr, r.success) for r in results} == {("a", True), ("b", False)}
+    assert up.pushed == {"/nix/store/a-out"}

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -2,8 +2,9 @@ import asyncio
 import json
 from typing import TYPE_CHECKING, Any
 
-from nix_fast_build.build import BuildQueue, JobQueue
+from nix_fast_build.build import JobQueue
 from nix_fast_build.options import Options
+from nix_fast_build.upload import UploadQueue
 from nix_fast_build.workers import run_evaluation
 
 if TYPE_CHECKING:
@@ -32,15 +33,15 @@ JOB = {
 }
 
 
-def _eval(opts: Options) -> tuple[JobQueue, BuildQueue]:
+def _eval(opts: Options) -> tuple[JobQueue, UploadQueue]:
     build_queue: JobQueue = JobQueue()
-    upload_queue: BuildQueue = BuildQueue()
+    upload_queue: UploadQueue = UploadQueue()
     result_queue: asyncio.Queue[Result | None] = asyncio.Queue()
     asyncio.run(
         run_evaluation(
             FakeEvalProc([JOB]),  # type: ignore[arg-type]
             build_queue,
-            upload_queue,
+            [upload_queue],
             result_queue,
             opts,
         )
@@ -65,7 +66,7 @@ def test_eval_result_reports_outputs_and_drv_path() -> None:
         run_evaluation(
             FakeEvalProc([{**JOB, "cacheStatus": "cached"}]),  # type: ignore[arg-type]
             JobQueue(),
-            None,
+            [],
             result_queue,
             Options(systems={"x86_64-linux"}),
         )


### PR DESCRIPTION
Walking nix-store -qR --include-outputs from the toplevel .drv could not tell built from substituted paths, missed build-only inputs and made --no-closure unsafe. Instead, emit each actBuild stop from the internal-json log into per-cache upload queues while the build is still running. One worker per cache drains the queue, resolves .drv outputs, drops invalid (failed) and already-pushed paths, and pushes the batch via stdin to stay clear of ARG_MAX. A failed batch is retried per attribute for exact attribution.

This makes the feature backend-agnostic, so --attic-push-build-closure becomes a deprecated alias for --push-build-closure. Locally cached attributes are now offered to every configured cache, not just --copy-to.