### PR TITLE
upload: fix result attribution found in live testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,22 @@ a custom path via the `NIKS3_AUTH_TOKEN_FILE` environment variable.
 When using the `--remote` flag, ensure that the auth token file exists on the
 remote machine (either at the default XDG path or via `NIKS3_AUTH_TOKEN_FILE`).
 
+## Caching intermediate build products
+
+By default only the final outputs of each attribute are pushed to the configured
+caches (`--copy-to`, `--cachix-cache`, `--attic-cache`, `--niks3-server`). On
+ephemeral CI runners with an empty nix store this means intermediate derivations
+that are not part of the runtime closure (build hooks, wheels, vendored deps,
+...) are rebuilt on every run.
+
+With `--push-build-closure`, nix-fast-build additionally pushes the outputs of
+every derivation nix actually built locally (as opposed to substituted) as soon
+as it finishes, even while the toplevel attribute is still building:
+
+```console
+$ nix-fast-build --attic-cache mic92 --push-build-closure
+```
+
 ## Machine-readable builds results
 
 nix-fast-build supports both its own json format and junit:
@@ -334,11 +350,10 @@ usage: nix-fast-build [-h] [--nix NIX] [--nix-eval-jobs NIX_EVAL_JOBS]
                       [--cachix-cache CACHIX_CACHE]
                       [--attic-cache ATTIC_CACHE]
                       [--attic-ignore-upstream-cache-filter]
-                      [--push-build-closure] [--attic-push-build-closure]
-                      [--niks3-server NIKS3_SERVER] [--no-nom] [--no-fold]
-                      [--stall-timeout STALL_TIMEOUT] [--systems SYSTEMS]
-                      [--retries RETRIES] [--no-link] [--out-link OUT_LINK]
-                      [--store STORE] [--remote REMOTE]
+                      [--push-build-closure] [--niks3-server NIKS3_SERVER]
+                      [--no-nom] [--no-fold] [--stall-timeout STALL_TIMEOUT]
+                      [--systems SYSTEMS] [--retries RETRIES] [--no-link]
+                      [--out-link OUT_LINK] [--store STORE] [--remote REMOTE]
                       [--always-upload-source] [--no-download] [--skip-cached]
                       [--copy-to COPY_TO] [--debug]
                       [--eval-max-memory-size EVAL_MAX_MEMORY_SIZE]
@@ -395,8 +410,6 @@ options:
                         soon as they finish. Useful for caching intermediate
                         build products in ephemeral CI environments (default:
                         false)
-  --attic-push-build-closure
-                        Deprecated alias for --push-build-closure
   --niks3-server NIKS3_SERVER
                         Niks3 server URL to upload to (auth from
                         ~/.config/niks3/auth-token or NIKS3_AUTH_TOKEN_FILE)

--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -287,7 +287,7 @@ async def parse_args(args: list[str]) -> Options:
     )
     parser.add_argument(
         "--attic-push-build-closure",
-        help="Deprecated alias for --push-build-closure",
+        help=argparse.SUPPRESS,
         action="store_true",
     )
     parser.add_argument(

--- a/nix_fast_build/upload.py
+++ b/nix_fast_build/upload.py
@@ -22,6 +22,8 @@ class UploadItem:
     attr: str
     # output paths or .drv paths (resolved to outputs by the worker)
     paths: list[str]
+    # toplevel outputs always yield a Result, intermediates only on failure
+    final: bool = True
 
 
 UploadQueue = QueueWithContext[UploadItem | StopTask]
@@ -172,16 +174,17 @@ async def run_upload_worker(
             items = _drain(queue, first)
 
             by_attr: dict[str, set[str]] = {}
+            final: set[str] = set()
             for item in items:
-                new = set(item.paths) - uploader.pushed
-                if new:
-                    by_attr.setdefault(item.attr, set()).update(new)
-            if not by_attr:
-                continue
+                by_attr.setdefault(item.attr, set()).update(
+                    set(item.paths) - uploader.pushed
+                )
+                if item.final:
+                    final.add(item.attr)
 
             start = timeit.default_timer()
             batch = set().union(*by_attr.values())
-            rc = await uploader.push(batch)
+            rc = await uploader.push(batch) if batch else 0
             rcs = dict.fromkeys(by_attr, rc)
             if rc != 0 and len(by_attr) > 1:
                 logger.warning(
@@ -191,11 +194,13 @@ async def run_upload_worker(
                     rc,
                 )
                 for attr, paths in by_attr.items():
-                    rcs[attr] = await uploader.push(paths)
+                    rcs[attr] = await uploader.push(paths) if paths else 0
             duration = (timeit.default_timer() - start) / len(by_attr)
             for attr, attr_rc in rcs.items():
                 if attr_rc == 0:
                     uploader.pushed.update(by_attr[attr])
+                if attr_rc == 0 and attr not in final:
+                    continue
                 await result_queue.put(
                     Result(
                         result_type=uploader.result_type,

--- a/nix_fast_build/workers.py
+++ b/nix_fast_build/workers.py
@@ -114,7 +114,7 @@ async def run_builds(
 
                 def on_built(drv: str, attr: str = job.attr) -> None:
                     for uq in upload_queues:
-                        uq.put_nowait(UploadItem(attr, [drv]))
+                        uq.put_nowait(UploadItem(attr, [drv], final=False))
 
             start_time = timeit.default_timer()
             build_result = await build.build(

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -75,11 +75,17 @@ def test_batches_resolves_drvs_filters_invalid_and_dedups() -> None:
         up,
         [
             [
-                UploadItem("a", ["/nix/store/x-lib.drv"]),
-                UploadItem("b", ["/nix/store/x-lib.drv", "/nix/store/y-broken.drv"]),
+                UploadItem("a", ["/nix/store/x-lib.drv"], final=False),
+                UploadItem(
+                    "b",
+                    ["/nix/store/x-lib.drv", "/nix/store/y-broken.drv"],
+                    final=False,
+                ),
                 UploadItem("a", ["/nix/store/a-out"]),
             ],
             [UploadItem("b", ["/nix/store/x-lib.drv", "/nix/store/b-out"])],
+            # alias attr with only already-pushed paths still gets a result
+            [UploadItem("a-alias", ["/nix/store/a-out"])],
         ],
     )
     assert up.calls == [
@@ -89,7 +95,7 @@ def test_batches_resolves_drvs_filters_invalid_and_dedups() -> None:
     assert [(r.attr, r.success) for r in results] == [
         ("a", True),
         ("b", True),
-        ("b", True),
+        ("a-alias", True),
     ]
 
 


### PR DESCRIPTION

Attributes whose paths were all deduped (aliases like package-default vs
package-nix-fast-build) got no upload result, while failed attributes got
a success result purely from their intermediates. Always report toplevel
items and report intermediates only on failure.

Also hide the deprecated --attic-push-build-closure from --help and
document --push-build-closure in the README.
