### PR TITLE
add --skip-unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ usage: nix-fast-build [-h] [--nix NIX] [--nix-eval-jobs NIX_EVAL_JOBS]
                       [--override-input input_path flake_url]
                       [--select NIX_FUNCTION]
                       [--reference-lock-file REFERENCE_LOCK_FILE]
-                      [--fail-fast]
+                      [--fail-fast] [--skip-unsupported]
 
 options:
   -h, --help            show this help message and exit
@@ -469,4 +469,7 @@ options:
                         within the top-level flake.
   --fail-fast           Stop as soon as any build or evaluation fails, instead
                         of continuing with remaining builds.
+  --skip-unsupported    Report attributes whose meta.platforms/badPlatforms
+                        exclude the evaluated system as skipped instead of
+                        failed
 ```

--- a/nix_fast_build/options.py
+++ b/nix_fast_build/options.py
@@ -68,6 +68,7 @@ class Options:
     override_inputs: list[list[str]] = field(default_factory=list)
     select_expr: str | None = None
     fail_fast: bool = False
+    skip_unsupported: bool = False
     reference_lock_file: str | None = None
 
     cachix_cache: str | None = None
@@ -294,6 +295,12 @@ async def parse_args(args: list[str]) -> Options:
         "--niks3-server",
         help="Niks3 server URL to upload to (auth from ~/.config/niks3/auth-token or NIKS3_AUTH_TOKEN_FILE)",
         default=None,
+    )
+    parser.add_argument(
+        "--skip-unsupported",
+        help="Report attributes whose meta.platforms/badPlatforms exclude the "
+        "evaluated system as skipped instead of failed",
+        action="store_true",
     )
     parser.add_argument(
         "--no-nom",
@@ -585,4 +592,5 @@ async def parse_args(args: list[str]) -> Options:
         select_expr=a.select,
         reference_lock_file=a.reference_lock_file,
         fail_fast=a.fail_fast,
+        skip_unsupported=a.skip_unsupported,
     )

--- a/nix_fast_build/report.py
+++ b/nix_fast_build/report.py
@@ -248,6 +248,7 @@ def dump_junit_xml(file: IO[str], suite_name: str, build_results: list[Result]) 
             "name": suite_name,
             "tests": str(len(build_results)),
             "failures": str(sum(1 for r in build_results if not r.success)),
+            "skipped": str(sum(1 for r in build_results if r.skipped)),
         },
     )
 
@@ -262,7 +263,9 @@ def dump_junit_xml(file: IO[str], suite_name: str, build_results: list[Result]) 
             },
         )
 
-        if not result.success:
+        if result.skipped:
+            ET.SubElement(testcase, "skipped", {"message": result.error or ""})
+        elif not result.success:
             failure = ET.SubElement(
                 testcase,
                 "failure",

--- a/nix_fast_build/results.py
+++ b/nix_fast_build/results.py
@@ -23,6 +23,7 @@ class Result:
     outputs: dict[str, str] | None = None
     drv_path: str | None = None
     cache_status: str | None = None
+    skipped: bool = False
 
     def as_dict(self) -> dict:
         return {
@@ -31,6 +32,7 @@ class Result:
             "success": self.success,
             "duration": self.duration,
             "error": self.error,
+            **({"skipped": True} if self.skipped else {}),
             **({"outputs": self.outputs} if self.outputs is not None else {}),
             **({"drvPath": self.drv_path} if self.drv_path is not None else {}),
             **(

--- a/nix_fast_build/workers.py
+++ b/nix_fast_build/workers.py
@@ -22,6 +22,10 @@ def _job_outputs(job: dict[str, Any]) -> dict[str, str]:
     return {k: v for k, v in job.get("outputs", {}).items() if v is not None}
 
 
+# nixpkgs check-meta wording for meta.platforms/badPlatforms mismatches
+UNSUPPORTED_MARKER = "is not available on the requested hostPlatform"
+
+
 async def run_evaluation(
     eval_proc: Process,
     build_queue: JobQueue,
@@ -47,21 +51,24 @@ async def run_evaluation(
         if cache_status is None and job.get("isCached", False):
             cache_status = "cached"
         outputs = _job_outputs(job)
+        skipped = bool(error and opts.skip_unsupported and UNSUPPORTED_MARKER in error)
         await result_queue.put(
             Result(
                 result_type=ResultType.EVAL,
                 attr=attr,
-                success=error is None,
+                success=error is None or skipped,
                 # TODO: maybe add this to nix-eval-jobs?
                 duration=0.0,
                 error=error,
                 outputs=outputs or None,
                 drv_path=job.get("drvPath"),
                 cache_status=cache_status,
+                skipped=skipped,
             )
         )
         if error:
-            opts.signal_stop()
+            if not skipped:
+                opts.signal_stop()
             continue
         # Skip remotely cached jobs, but still consider
         # them for pushing if they are cached locally

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -78,3 +78,42 @@ def test_eval_result_reports_outputs_and_drv_path() -> None:
     assert data["outputs"] == {"out": "/nix/store/aaa-foo"}
     assert data["drvPath"] == "/nix/store/aaa-foo.drv"
     assert data["cacheStatus"] == "cached"
+
+
+UNSUPPORTED_JOB = {
+    "attr": "bar",
+    "error": "error: Package bar-1.0 in /x is not available on the requested "
+    'hostPlatform:\n  hostPlatform.system = "x86_64-linux"',
+}
+
+
+def _eval_error(opts: Options) -> "Result":
+    result_queue: asyncio.Queue[Result | None] = asyncio.Queue()
+    asyncio.run(
+        run_evaluation(
+            FakeEvalProc([UNSUPPORTED_JOB]),  # type: ignore[arg-type]
+            JobQueue(),
+            [],
+            result_queue,
+            opts,
+        )
+    )
+    result = result_queue.get_nowait()
+    assert result is not None
+    return result
+
+
+def test_unsupported_platform_fails_by_default() -> None:
+    opts = Options(fail_fast=True)
+    result = _eval_error(opts)
+    assert not result.success
+    assert not result.skipped
+    assert opts.should_stop
+
+
+def test_skip_unsupported_reports_skipped() -> None:
+    opts = Options(fail_fast=True, skip_unsupported=True)
+    result = _eval_error(opts)
+    assert result.success
+    assert result.as_dict()["skipped"] is True
+    assert not opts.should_stop


### PR DESCRIPTION
Packages whose meta.platforms exclude the evaluated system fail eval in
check-meta, which made the whole run fail. With the flag such attributes
are reported as skipped (result file, junit <skipped/>, CI summary) and
do not trigger --fail-fast.

Closes #414
